### PR TITLE
Update the index.html to address the i18n issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1145,30 +1145,34 @@
 	  </p>
 	  
 	  <p>i18n/en-US.json</p>
-	  </div> <pre aria-busy="false"><code class="hljs json">{
-  <span class="hljs-attr">"strings"</span>: { 
-    <span class="hljs-attr">"name"</span>:<span class="hljs-string">"miniapp demo"</span>,
-    <span class="hljs-attr">"short_name"</span>:<span class="hljs-string">"MD"</span>,
-    <span class="hljs-attr">"description_application"</span>:<span class="hljs-string">"MiniApp Demo"</span>,
-  },
-  <span class="hljs-attr">"files"</span>: {
-    <span class="hljs-attr">"images"</span>:<span class="hljs-string">"image/en_picture.PNG"</span>,
-  },  
-} 
-  </code></pre>  
+	  </div> 
+	  <pre class="example json">
+	  {
+	   "strings": { 
+       "name":"miniapp demo",
+       "short_name":"MD",
+       "description_application":"MiniApp Demo",
+       },
+       "files": {
+       "images":"image/en_picture.PNG",
+       },  
+      } 
+	  </pre>
 
 	  <p>i18n/zh-Hans.json</p>
-	  </div> <pre aria-busy="false"><code class="hljs json">{
-  <span class="hljs-attr">"strings"</span>: { 
-    <span class="hljs-attr">"name"</span>:<span class="hljs-string">"小程序试用版"</span>,
-    <span class="hljs-attr">"short_name"</span>:<span class="hljs-string">"小程序"</span>,
-    <span class="hljs-attr">"description_application"</span>:<span class="hljs-string">"迷你程序试用版本"</span>,
+	  </div> 
+	  <pre class="example json">
+{
+  "strings": { 
+    "name":"小程序试用版",
+    "short_name":"小程序",
+    "description_application":"迷你程序试用版本",
   },
-  <span class="hljs-attr">"files"</span>: {
-    <span class="hljs-attr">"images"</span>:<span class="hljs-string">"image/zh_picture.PNG"</span>,
+  "files": {
+    "images":"image/zh_picture.PNG",
   },  
 } 
-  </code></pre>
+</pre>
 
 	  <p its-locale-filter-list="en" lang="en"> 
 	   Developers can refer to a resource using the syntax $string:&lsaquo;resource-name&rsaquo;, for example, "decscription": "$string:description_application".
@@ -1184,24 +1188,25 @@
 	  以下例子描述一个简单的支持多语言的manifest片段：
 	  </p>	  
 
-<pre aria-busy="false"><code class="hljs json">{
-  <span class="hljs-attr">"dir"</span>:<span class="hljs-string">"ltr"</span>,
-  <span class="hljs-attr">"lang"</span>:<span class="hljs-string">"en-US"</span>,
-  <span class="hljs-attr">"appID"</span>:<span class="hljs-string">"org.w3c.miniapp"</span>,
-  <span class="hljs-attr">"name"</span>:<span class="hljs-string">"$string:name"</span>,
-  <span class="hljs-attr">"short_name"</span>:<span class="hljs-string">"$string:short_name"</span>,
-  <span class="hljs-attr">"versionName"</span>:<span class="hljs-string">"1.0.0"</span>,
-  <span class="hljs-attr">"versionCode"</span>:<span class="hljs-string">"1"</span>,
-  <span class="hljs-attr">"description"</span>:<span class="hljs-string">"$string:description_application"</span>,
-  <span class="hljs-attr">"icons"[
+	  <pre class="example json">
+{
+  "dir":"ltr",
+  "lang":"en-US",
+  "appID":"org.w3c.miniapp",
+  "name":"$string:name",
+  "short_name":"$string:short_name",
+  "versionName":"1.0.0",
+  "versionCode":"1",
+  "description":"$string:description_application",
+  "icons"[
     {
-      <span class="hljs-attr">"src"</span>:<span class="hljs-string">"common/icons/icon.png"</span>,
-      <span class="hljs-attr">"sizes"</span>:<span class="hljs-string">"48x48"</span>,	  
+      "src":"common/icons/icon.png",
+      "sizes":"48x48",	  
 	} 
   ],
   ...  
 } 
-  </code></pre>  
+</pre>  
   
  	  <p its-locale-filter-list="en" lang="en"> 
 	   In this way, when reading the MiniApp Manifest, the MiniApp processor, such as marketplace, can extract the string resource information from the corresponding language file in the MiniApp package's i18n directory according to the configuration information of itself and generates the localized description. For example, if the configuration information of the marketplace is simplified Chinese, the marketplace parses the "name": "$string: name" statement in the manifest and extracts sting: name information from the zh-Hans.json file in the MiniApp package's i18n directory. And then it generates the localized name of the MiniApp: 小程序试用版。

--- a/index.html
+++ b/index.html
@@ -1104,13 +1104,13 @@
 
     <section>
       <h2>
-          <span its-locale-filter-list="en" lang="en"><dfn>Internationalization</dfn></span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans"><dfn>国际化方案</dfn></span>
+          <span its-locale-filter-list="en" lang="en">Internationalization</span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans">国际化方案</span>
       </h2>
     <section>
       <h2>
-          <span its-locale-filter-list="en" lang="en"><dfn>Localizable members</dfn></span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans"><dfn>可本地化属性</dfn></span>
+          <span its-locale-filter-list="en" lang="en">Localizable members</span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans">可本地化属性</span>
       </h2>
       <p its-locale-filter-list="en" lang="en">
           The following members are localizable and share the same default configuration of <code>dir</code> and <code>lang</code> if not otherwise specified.
@@ -1128,8 +1128,8 @@
     </section>
     <section>
       <h2>
-          <span its-locale-filter-list="en" lang="en"><dfn>I18n Solution</dfn></span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans"><dfn>I18n方案</dfn></span>
+          <span its-locale-filter-list="en" lang="en">I18n Solution</span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans">I18n方案</span>
       </h2>	  
       <p its-locale-filter-list="en" lang="en">
           To support the multiple languages, attributes such as name, short_name, and description can be set as a reference to a string resource. Typically, string resources are stored in the corresponding multi-language JSON file in the MiniApp package's i18n directory. The multi-language file’s name complies with IETF BCP 47.</p>

--- a/index.html
+++ b/index.html
@@ -1102,11 +1102,11 @@
       <div class="issue" data-number='117'></div>
     </section>
 
-    <section id="Internationalization">
-      <h2 id="x6-Internationalization">
-          <span its-locale-filter-list="en" lang="en"><dfn id="dfn-Internationalization">Internationalization</dfn></span>
-          <span its-locale-filter-list="zh-hans" lang="zh-hans"><dfn id="dfn-generatedID">国际化方案</dfn></span>
-      <a class="self-link" aria-label="§" href="#Internationalization"></a></h2>
+    <section>
+      <h2>
+          <span its-locale-filter-list="en" lang="en"><dfn>Internationalization</dfn></span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans"><dfn>国际化方案</dfn></span>
+      </h2>
     <section>
       <h2>
           <span its-locale-filter-list="en" lang="en"><dfn>Localizable members</dfn></span>

--- a/index.html
+++ b/index.html
@@ -1102,6 +1102,11 @@
       <div class="issue" data-number='117'></div>
     </section>
 
+    <section id="Internationalization">
+      <h2 id="x6-Internationalization">
+          <span its-locale-filter-list="en" lang="en"><dfn id="dfn-Internationalization">Internationalization</dfn></span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans"><dfn id="dfn-generatedID">国际化方案</dfn></span>
+      <a class="self-link" aria-label="§" href="#Internationalization"></a></h2>
     <section>
       <h2>
           <span its-locale-filter-list="en" lang="en"><dfn>Localizable members</dfn></span>
@@ -1120,6 +1125,92 @@
           <li><a>MiniAppWindowResource.navigationBarTitleText</a></li>
           <li><a>MiniAppWidgetResource.name</a></li>
       </ul>
+    </section>
+    <section>
+      <h2>
+          <span its-locale-filter-list="en" lang="en"><dfn>I18n Solution</dfn></span>
+          <span its-locale-filter-list="zh-hans" lang="zh-hans"><dfn>I18n方案</dfn></span>
+      </h2>	  
+      <p its-locale-filter-list="en" lang="en">
+          To support the multiple languages, attributes such as name, short_name, and description can be set as a reference to a string resource. Typically, string resources are stored in the corresponding multi-language JSON file in the MiniApp package's i18n directory. The multi-language file’s name complies with IETF BCP 47.</p>
+      <p its-locale-filter-list="zh-hans" lang="zh-hans">
+          为了支持多语言能力name, short_name, description等参数可以被设置为字符串资源的索引。通常情况下字符串资源被保存在MiniApp包i18n目录下相应的多语言文件中。多语言文件命名规范符合IETF BCP 47。
+      </p>
+	  
+	  <p its-locale-filter-list="en" lang="en"> 
+	   The following example describes two simple multi-language files:
+	  </p>
+	  <p its-locale-filter-list="zh-hans" lang="zh-hans">
+	  以下例子描述2个简单的多语言文：
+	  </p>
+	  
+	  <p>i18n/en-US.json</p>
+	  </div> <pre aria-busy="false"><code class="hljs json">{
+  <span class="hljs-attr">"strings"</span>: { 
+    <span class="hljs-attr">"name"</span>:<span class="hljs-string">"miniapp demo"</span>,
+    <span class="hljs-attr">"short_name"</span>:<span class="hljs-string">"MD"</span>,
+    <span class="hljs-attr">"description_application"</span>:<span class="hljs-string">"MiniApp Demo"</span>,
+  },
+  <span class="hljs-attr">"files"</span>: {
+    <span class="hljs-attr">"images"</span>:<span class="hljs-string">"image/en_picture.PNG"</span>,
+  },  
+} 
+  </code></pre>  
+
+	  <p>i18n/zh-Hans.json</p>
+	  </div> <pre aria-busy="false"><code class="hljs json">{
+  <span class="hljs-attr">"strings"</span>: { 
+    <span class="hljs-attr">"name"</span>:<span class="hljs-string">"小程序试用版"</span>,
+    <span class="hljs-attr">"short_name"</span>:<span class="hljs-string">"小程序"</span>,
+    <span class="hljs-attr">"description_application"</span>:<span class="hljs-string">"迷你程序试用版本"</span>,
+  },
+  <span class="hljs-attr">"files"</span>: {
+    <span class="hljs-attr">"images"</span>:<span class="hljs-string">"image/zh_picture.PNG"</span>,
+  },  
+} 
+  </code></pre>
+
+	  <p its-locale-filter-list="en" lang="en"> 
+	   Developers can refer to a resource using the syntax $string:&lsaquo;resource-name&rsaquo;, for example, "decscription": "$string:description_application".
+	  </p>
+	  <p its-locale-filter-list="zh-hans" lang="zh-hans">
+	  用户可以使用$string:&lsaquo;resource-name&rsaquo;的方式引用字符串资源，例如："decscription": "$string:description_application".
+	  </p>	  
+	  
+	  <p its-locale-filter-list="en" lang="en"> 
+	   The following example describes a simple manifest fragment that supports multiple languages capability:
+	  </p>
+	  <p its-locale-filter-list="zh-hans" lang="zh-hans">
+	  以下例子描述一个简单的支持多语言的manifest片段：
+	  </p>	  
+
+<pre aria-busy="false"><code class="hljs json">{
+  <span class="hljs-attr">"dir"</span>:<span class="hljs-string">"ltr"</span>,
+  <span class="hljs-attr">"lang"</span>:<span class="hljs-string">"en-US"</span>,
+  <span class="hljs-attr">"appID"</span>:<span class="hljs-string">"org.w3c.miniapp"</span>,
+  <span class="hljs-attr">"name"</span>:<span class="hljs-string">"$string:name"</span>,
+  <span class="hljs-attr">"short_name"</span>:<span class="hljs-string">"$string:short_name"</span>,
+  <span class="hljs-attr">"versionName"</span>:<span class="hljs-string">"1.0.0"</span>,
+  <span class="hljs-attr">"versionCode"</span>:<span class="hljs-string">"1"</span>,
+  <span class="hljs-attr">"description"</span>:<span class="hljs-string">"$string:description_application"</span>,
+  <span class="hljs-attr">"icons"[
+    {
+      <span class="hljs-attr">"src"</span>:<span class="hljs-string">"common/icons/icon.png"</span>,
+      <span class="hljs-attr">"sizes"</span>:<span class="hljs-string">"48x48"</span>,	  
+	} 
+  ],
+  ...  
+} 
+  </code></pre>  
+  
+ 	  <p its-locale-filter-list="en" lang="en"> 
+	   In this way, when reading the MiniApp Manifest, the MiniApp processor, such as marketplace, can extract the string resource information from the corresponding language file in the MiniApp package's i18n directory according to the configuration information of itself and generates the localized description. For example, if the configuration information of the marketplace is simplified Chinese, the marketplace parses the "name": "$string: name" statement in the manifest and extracts sting: name information from the zh-Hans.json file in the MiniApp package's i18n directory. And then it generates the localized name of the MiniApp: 小程序试用版。
+	  </p>
+	  <p its-locale-filter-list="zh-hans" lang="zh-hans">
+	  通过上述方式，应用市场在读取应用manifest时，会根据自身的配置信息，从i18n目录下相应的语言文件，提取字符串信息，生成本地描述。例如 应用市场配置信息为汉语简体，则应用市场会解析manifest中"name": "$string:name"语句，从i18n目录的zh-Hans.json文件，提取sting:name信息：小程序试用版，并在应用市场生成该应用的本地化名称：小程序试用版。
+	  </p>	  
+     
+	     </section>
     </section>
 
   <section>

--- a/index.html
+++ b/index.html
@@ -1188,25 +1188,24 @@
 	  以下例子描述一个简单的支持多语言的manifest片段：
 	  </p>	  
 
-	  <pre class="example json">
-{
-  "dir":"ltr",
-  "lang":"en-US",
-  "appID":"org.w3c.miniapp",
-  "name":"$string:name",
-  "short_name":"$string:short_name",
-  "versionName":"1.0.0",
-  "versionCode":"1",
-  "description":"$string:description_application",
-  "icons"[
-    {
-      "src":"common/icons/icon.png",
-      "sizes":"48x48",	  
-	} 
-  ],
-  ...  
-} 
-</pre>  
+            <pre class="example json">
+              {
+                "dir": "ltr",
+                "lang": "en-US",
+                "appID": "org.w3c.miniapp",
+                "name": "$string:name",
+                "short_name": "string:short_name",
+                "versionName": "1.0.0",
+                "versionCode": 1,
+                "description": "$string:description_application",
+                "icons": [
+                  {
+                    "src": "common/icons/icon.png",
+                    "sizes": "48x48"
+                  }
+                ]
+              }
+            </pre>  
   
  	  <p its-locale-filter-list="en" lang="en"> 
 	   In this way, when reading the MiniApp Manifest, the MiniApp processor, such as marketplace, can extract the string resource information from the corresponding language file in the MiniApp package's i18n directory according to the configuration information of itself and generates the localized description. For example, if the configuration information of the marketplace is simplified Chinese, the marketplace parses the "name": "$string: name" statement in the manifest and extracts sting: name information from the zh-Hans.json file in the MiniApp package's i18n directory. And then it generates the localized name of the MiniApp: 小程序试用版。

--- a/index.html
+++ b/index.html
@@ -1211,7 +1211,7 @@
 	   In this way, when reading the MiniApp Manifest, the MiniApp processor, such as marketplace, can extract the string resource information from the corresponding language file in the MiniApp package's i18n directory according to the configuration information of itself and generates the localized description. For example, if the configuration information of the marketplace is simplified Chinese, the marketplace parses the "name": "$string: name" statement in the manifest and extracts string: name information from the zh-Hans.json file in the MiniApp package's i18n directory. And then it generates the localized name of the MiniApp: 小程序试用版。
 	  </p>
 	  <p its-locale-filter-list="zh-hans" lang="zh-hans">
-	  通过上述方式，应用市场在读取应用manifest时，会根据自身的配置信息，从i18n目录下相应的语言文件，提取字符串信息，生成本地描述。例如 应用市场配置信息为汉语简体，则应用市场会解析manifest中"name": "$string:name"语句，从i18n目录的zh-Hans.json文件，提取sting:name信息：小程序试用版，并在应用市场生成该应用的本地化名称：小程序试用版。
+	  通过上述方式，应用市场在读取应用manifest时，会根据自身的配置信息，从i18n目录下相应的语言文件，提取字符串信息，生成本地描述。例如 应用市场配置信息为汉语简体，则应用市场会解析manifest中"name": "$string:name"语句，从i18n目录的zh-Hans.json文件，提取string:name信息：小程序试用版，并在应用市场生成该应用的本地化名称：小程序试用版。
 	  </p>	  
      
 	     </section>

--- a/index.html
+++ b/index.html
@@ -1208,7 +1208,7 @@
             </pre>  
   
  	  <p its-locale-filter-list="en" lang="en"> 
-	   In this way, when reading the MiniApp Manifest, the MiniApp processor, such as marketplace, can extract the string resource information from the corresponding language file in the MiniApp package's i18n directory according to the configuration information of itself and generates the localized description. For example, if the configuration information of the marketplace is simplified Chinese, the marketplace parses the "name": "$string: name" statement in the manifest and extracts sting: name information from the zh-Hans.json file in the MiniApp package's i18n directory. And then it generates the localized name of the MiniApp: 小程序试用版。
+	   In this way, when reading the MiniApp Manifest, the MiniApp processor, such as marketplace, can extract the string resource information from the corresponding language file in the MiniApp package's i18n directory according to the configuration information of itself and generates the localized description. For example, if the configuration information of the marketplace is simplified Chinese, the marketplace parses the "name": "$string: name" statement in the manifest and extracts string: name information from the zh-Hans.json file in the MiniApp package's i18n directory. And then it generates the localized name of the MiniApp: 小程序试用版。
 	  </p>
 	  <p its-locale-filter-list="zh-hans" lang="zh-hans">
 	  通过上述方式，应用市场在读取应用manifest时，会根据自身的配置信息，从i18n目录下相应的语言文件，提取字符串信息，生成本地描述。例如 应用市场配置信息为汉语简体，则应用市场会解析manifest中"name": "$string:name"语句，从i18n目录的zh-Hans.json文件，提取sting:name信息：小程序试用版，并在应用市场生成该应用的本地化名称：小程序试用版。


### PR DESCRIPTION
Update the MiniApp Manifest index.html to address the i18n issues, I rewrite section 6 add a subsection to provide an i18n solution. #4 #5 #6， @aphillips @zhangyongjing @xfq


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MichaelWangzitao/miniapp-manifest/pull/12.html" title="Last updated on Mar 17, 2021, 8:53 AM UTC (dfaf775)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/12/ff904b3...MichaelWangzitao:dfaf775.html" title="Last updated on Mar 17, 2021, 8:53 AM UTC (dfaf775)">Diff</a>