### PR TITLE
Modified the version_code, version_name, and min_platform_version member

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
           <span><code>platform_version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>platform_version</code></dfn> member contains a <a>MiniApp platform version resource</a> [=object=] to represent the <dfn><code>min_platform_version</code></dfn>, <dfn><code>target_platform_version</code></dfn>, and <dfn><code>release_type</code></dfn>.
+          The [=MiniApp manifest's=] <dfn><code>platform_version</code></dfn> member contains a <a>MiniApp platform version resource</a> [=object=] to represent the <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_platform_version</code></a>, <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_platform_version</code></a>, and <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>release_type</code></a>.
         </p>
 
 
@@ -1061,7 +1061,7 @@
       <h3><code>release_type</code> member</h3>
 
         <p>
-          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>release_type</code></dfn> member is a [=string=] that Indicates the release type of the target API version required for running the application. The value can be CanaryN, BetaN, or Release. N represents a positive integer. (e.g., <code>"Beta1"</code>).
+          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>release_type</code></dfn> member is a [=string=] that indicates the release type of the target API version required for running the application. The value can be CanaryN, BetaN, or Release. N represents a positive integer. (e.g., <code>"Beta1"</code>).
         </p>
        
         <p>
@@ -1205,7 +1205,7 @@
         The optional [=MiniApp widget resource's=] <dfn data-dfn-for="MiniApp widget resource"><code>min_platform_version</code></dfn> member is a [=string=] that indicates the minimum platform version supported for a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-widget">MiniApp widget</a>.
       </p>
       <p class="note" title='Usage'>
-        Since Widget APIs and MiniApp APIs may differ, the declaration of the minimum version of the platform may be different. Thus, if the widgets member omits <a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_platform_version</code></a> explicitly, the user agent will consider the same requirement as the specified in the <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>min_platform_version</code></a> member at the root of the [=manifest=].
+        Since Widget APIs and MiniApp APIs may differ, the declaration of the minimum version of the platform may be different. Thus, if the widgets member omits <a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_platform_version</code></a> explicitly, the user agent will consider the same requirement as the specified in the <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_platform_version</code></a> member in the <a><code>platform_version</code></a> object.
         </p>
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     </style>
 
     <script async class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
-    <!-- <script defer src="https://w3c.github.io/miniapp/specs/script.js"></script> -->
+    <script defer src="https://w3c.github.io/miniapp/specs/script.js"></script>
 
     <script class="remove">
         var respecConfig = {
@@ -134,13 +134,11 @@
           <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>
         </li>
         <li>
-          <a><code>version_name</code></a>
+          <a><code>version</code></a>
         </li>  
+
         <li>
-          <a><code>version_code</code></a>
-        </li>
-        <li>
-          <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>min_platform_version</code></a>
+          <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>platform_version</code></a>
         </li>
         <li>
           <a><code>pages</code></a>
@@ -237,11 +235,11 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp manifest" data-link-type="dfn"><code>min_platform_version</code></a></th>
-            <td> [=string=] </td>
-            <td>Yes</td>
+            <th scope="row"><a data-link-for="MiniApp manifest" data-link-type="dfn"><code>platform_version</code></a></th>
+            <td> <a>platform version resource</a> </td>
+			<td>Yes</td>
             <td>
-              <span>Minimum platform version supported</span>
+              <span>Platform version supported</span>
             </td>
           </tr>
           <tr>
@@ -275,21 +273,14 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>version_code</code></a></th>
-            <td> [=string=] </td>
+            <th scope="row"><a><code>version</code></a></th>
+            <td> <a>version resource</a> </td>
             <td>Yes</td>
             <td>
-              <span>Version code</span>
+              <span>MiniApp Version</span>
             </td>
           </tr>          
-          <tr>
-            <th scope="row"><a><code>version_name</code></a></th>
-            <td> [=string=] </td>
-            <td>Yes</td>
-            <td>
-              <span>Version name</span>
-            </td>
-          </tr>
+
           <tr>
             <th scope="row"><a><code>widgets</code></a></th>
             <td> <a>widget resource</a> [=array=] </td>
@@ -347,6 +338,47 @@
       </table>
 
       <table class="members">
+        <caption>Members of [=platform version resource=] objects<br/>(<a><code>platform_version</code></a> object)</caption>
+        <thead>
+          <tr>
+            <th scope="col">Member</th>
+            <th scope="col">Type</th>
+            <th scope="col">Required</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_platform_version</code></a></th>
+            <td> [=string=]  </td>
+            <td>Yes</td>
+            <td>
+                <span>Indicates the minimum platform version required for running the MiniApp. </span>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_platform_version</code></a></th>
+            <td> [=string=] </td>
+            <td>No</td>
+            <td>
+              <span>Indicates the target platform version required for running the application. </span>
+            </td>
+          </tr>
+		  
+          <tr>
+            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>release_type</code></a></th>
+            <td> [=string=] </td>
+            <td>No</td>
+            <td>
+              <span>Indicates the release type of the target platform version required for running the application. The value can be CanaryN, BetaN, or Release. N represents a positive integer. 1) Canary: indicates a restrictedly released version. 2) Beta: indicates a publicly released beta version. 3)Release: indicates a publicly released official version. </span>
+            </td>
+          </tr>		  
+        </tbody>
+      </table>
+
+
+
+      <table class="members">
         <caption>Members of [=permission resource=] objects<br/>(<a><code>req_permissions</code></a> array)</caption>
         <thead>
           <tr>
@@ -373,6 +405,36 @@
                 <span>Reason to request the permission</span>
             </td>
           </tr>          
+        </tbody>
+      </table>
+
+      <table class="members">
+        <caption>Members of [=version resource=] objects<br/>(<a><code>version</code></a> object)</caption>
+        <thead>
+          <tr>
+            <th scope="col">Member</th>
+            <th scope="col">Type</th>
+            <th scope="col">Required</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>version_code</code></a></th>
+            <td> [=string=]  </td>
+            <td>Yes</td>
+            <td>
+                <span>Version code</span>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>version_name</code></a></th>
+            <td> [=string=] </td>
+            <td>Yes</td>
+            <td>
+              <span>Version Name</span>
+            </td>
+          </tr>
         </tbody>
       </table>
 
@@ -524,6 +586,9 @@
         </tbody>
       </table>
 
+
+
+
       <p class="note">
       Other [=application manifest=] members such as <a href="https://www.w3.org/TR/appmanifest/#scope-member"><code>scope</code></a>,
         <a href="https://www.w3.org/TR/appmanifest/#theme_color-member"><code>theme_color</code></a>,
@@ -546,8 +611,10 @@
           "app_id": "org.example.miniapp",
           "name": "MiniApp Demo",
           "short_name": "MiniApp",
-          "version_name": "1.0.1",
-          "version_code": 11,
+          "version": {
+            "version_name": "1.0.1",
+            "version_code": 11
+          },
           "description": "A Simple MiniApp Demo",
           "icons": [
             {
@@ -555,7 +622,11 @@
               "sizes": "48x48"
             }
           ],
-          "min_platform_version": "1.0.0",
+          "platform_version":{
+            "min_platform_version": "1.0.0",
+            "target_platform_version": "1.2.1",
+            "release_type": "Beta1"			
+          },
           "pages": [
             "pages/index/index",
             "pages/detail/detail"
@@ -722,24 +793,31 @@
           <li>Set |manifest|["app_id"] to |json|["app_id"].</li>
         </ol>        
       </section>
+	  
       <section>
         <h3>
-          <span><code>min_platform_version</code> member</span>
+          <span><code>platform_version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn data-dfn-for="MiniApp manifest"><code>min_platform_version</code></dfn> member is a [=string=] that indicates the minimum supported version of the MiniApp user agent's platform to ensure the regular operation of a MiniApp (e.g., <code>"1.0.0"</code>).
+          The [=MiniApp manifest's=] <dfn><code>platform_version</code></dfn> member contains a <a>MiniApp platform version resource</a> [=object=] to represent the <dfn><code>min_platform_version</code></dfn>, <dfn><code>target_platform_version</code></dfn>, and <dfn><code>release_type</code></dfn>.
         </p>
-        <p class="note" title='Usage'>
-          The RECOMMENDED format for this member is <code>"X.Y.Z"</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>"1.10.0"</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
-        </p>        
+
+
+
         <p>
-          To <dfn>process the <code>min_platform_version</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
+          To <dfn>process the <code>platform_version</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If |json|["min_platform_version"] does not [=map/exist=], or if the type of |json|["min_platform_version"] is not [=string=], return failure.</li>
-          <li>Set |manifest|["min_platform_version"] to |json|["min_platform_version"].</li>
-        </ol>         
+          <li>If |json|["platform_version"] does not [=map/exist=], or if the type of |json|["platform_version"] is not [=object=], return.</li>
+          <li>Let |version:ordered map| be a new [=ordered map=].</li>
+          <li><a>Process the platform version's <code>min_platform_version</code> member</a> passing |json|["platform_version"] and |platform_version|.</li>
+          <li><a>Process the platform version's <code>target_platform_version</code> member</a> passing |json|["platform_version"] and |platform_version|.</li>         
+          <li><a>Process the platform version's <code>release_type</code> member</a> passing |json|["platform_version"] and |platform_version|.</li> 
+          <li>If |platform_version|["min_platform_version"] does not [=map/exist=], return failure.</li>  		  
+		  <li>Set |manifest|["platform_version"] to |platform_version|.</li>
+        </ol>             
       </section>
+	  
       <section>
         <h3>
           <span><code>pages</code> member</span>
@@ -812,51 +890,31 @@
         <p class="note" title="Protection of user's privacy">
           User agents will ask for the user's consent to protect their privacy during access to these specific features. This information in the <a><code>req_permissions</code></a> member may be used by app stores or hosting platforms to filter MiniApps according to the user's preferences, privacy policy, or device capabilities. 
         </p>
-      </section>      
+      </section> 
+
       <section>
         <h3>
-          <span><code>version_code</code> member</span>
+          <span><code>version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>version_code</code></dfn> member is a non-negative integer [=number=] that represents the version of a MiniApp. It is mainly used for enhancing the maintainability and security of MiniApp (e.g., compatibility among incremental versions). The <a><code>version_code</code></a> member aims at supporting the development and deployment process, and it is not usually displayed to the end-user.
+          The [=MiniApp manifest's=] <dfn><code>version</code></dfn> member contains a <a>MiniApp version resource</a> [=object=] to represent the <dfn><code>version_code</code></dfn> and <dfn><code>version_name</code></dfn>.
         </p>
+
+
+
         <p>
-          Value by default: <code>1</code>.
-        </p>
-        <div class="note" title='Usage'>
-          <p>
-            The value of this member is usually incremented according to the version iteration process.
-          </p>
-        </div>
-        <p>
-          To <dfn>process the <code>version_code</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
+          To <dfn>process the <code>version</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If |json|["version_name"] does not [=map/exist=], or if the type of |json|["version_code"] is not [=number=], return failure.</li>
-          <li>Let |version:number| be a [=number=], initially 1.</li>
-          <li>If |json|["version_code"] is greater than 0, then: <br/>
-            Set |version| to |json|["version_code"].</li>
-          <li>Set |manifest|["version_code"] to |version|.</li>
-        </ol>        
+          <li>If |json|["version"] does not [=map/exist=], or if the type of |json|["version"] is not [=object=], return.</li>
+          <li>Let |version:ordered map| be a new [=ordered map=].</li>
+          <li><a>Process the version's <code>version_code</code> member</a> passing |json|["version"] and |version|.</li>
+          <li><a>Process the version's <code>version_name</code> member</a> passing |json|["version"] and |version|.</li>          
+		  <li>Set |manifest|["version"] to |version|.</li>
+        </ol>             
       </section>
-      <section>
-        <h3>
-          <span><code>version_name</code> member</span>
-        </h3>
-        <p>
-          The [=MiniApp manifest's=] <dfn><code>version_name</code></dfn> member is a [=string=] mainly used for describing information on the version of a MiniApp, playing an essential role in version control, MiniApp application, and platform compatibility. It is usually considered as the version that is shown publicly and displayed to the user.
-        </p>
-        <p class="note" title='Usage'>
-          The RECOMMENDED format for this member is <code>X.Y.Z</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>1.10.0</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
-        </p>
-        <p>
-          To <dfn>process the <code>version_name</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
-        </p>
-        <ol class="algorithm">
-          <li>If |json|["version_name"] does not [=map/exist=], or if the type of |json|["version_name"] is not [=string=], return failure.</li>
-          <li>Set |manifest|["version_name"] to |json|["version_name"].</li>
-        </ol>
-      </section>
+	  
+
       <section>
         <h3>
           <span><code>widgets</code> member</span>
@@ -877,8 +935,7 @@
           <li><a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>;</li>
           <li><a><code>short_name</code></a>;</li>
           <li><a><code>icons</code></a>;</li>
-          <li><a><code>version_name</code></a>; and</li>
-          <li><a><code>version_code</code></a></li>
+          <li><a><code>version</code></a></li>
         </ul>
         <p>
           However, a widget also has its exclusive fields as defined in the <a>MiniApp widget resource</a>.
@@ -945,15 +1002,78 @@
       <ol class="algorithm">
         <li><a>Process the <code>app_id</code> member</a> passing |json| and |manifest|.</li>
         <li><a>Process the <code>description</code> member</a> passing |json| and |manifest|.</li>
-        <li><a>Process the <code>min_platform_version</code> member</a> passing |json| and |manifest|.</li>
+        <li><a>Process the <code>platform_version</code> member</a> passing |json| and |manifest|.</li>
         <li><a>Process the <code>pages</code> member</a> passing |json| and |manifest|.</li>
         <li><a>Process the <code>req_permissions</code> member</a> passing |json| and |manifest|.</li>
-        <li><a>Process the <code>version_code</code> member</a> passing |json| and |manifest|.</li>
-        <li><a>Process the <code>version_name</code> member</a> passing |json| and |manifest|.</li>
+        <li><a>Process the <code>version</code> member</a> passing |json| and |manifest|.</li>
         <li><a>Process the <code>widgets</code> member</a> passing |json| and |manifest|.</li>
         <li><a>Process the <code>window</code> member</a> passing |json| and |manifest|.</li>
       </ol>      
     </section>
+  </section>
+
+
+  <section id="sec-platform-version-resources">
+    <h2>MiniApp platform version resources</h2>
+    <p>
+      A <dfn data-lt="platform version resource|MiniApp platform version resources|MiniApp platform version resource's">MiniApp platform version resource</dfn> is an [=object=] that indicates the minimum and target platform versions to be used by the MiniApp.
+    </p>
+    <p>
+      The following members are defined under the scope of the [=MiniApp manifest=], addressing specific aspects of a [=platform version resource=].
+    </p>
+    <section>
+      <h3><code>min_platform_version</code> member</h3>
+
+        <p>
+          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>min_platform_version</code></dfn> member is a [=string=] that indicates the minimum supported version of the MiniApp user agent's platform to ensure the regular operation of a MiniApp (e.g., <code>"1.0.0"</code>).
+        </p>
+        <p class="note" title='Usage'>
+          The RECOMMENDED format for this member is <code>"X.Y.Z"</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>"1.10.0"</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
+        </p>        
+        <p>
+          To <dfn>process the platform version's <code>min_platform_version</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |platform_version:ordered map|:
+        </p>
+        <ol class="algorithm">
+          <li>If |json|["min_platform_version"] does not [=map/exist=], or if the type of |json|["min_platform_version"] is not [=string=], return failure.</li>
+          <li>Set |platform_version|["min_platform_version"] to |json|["min_platform_version"].</li>
+        </ol>                 
+    </section>
+	
+    <section>
+      <h3><code>target_platform_version</code> member</h3>
+
+        <p>
+          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>target_platform_version</code></dfn> member is a [=string=] that indicates the target supported version of the MiniApp user agent's platform to ensure the regular operation of a MiniApp (e.g., <code>"1.0.0"</code>).
+        </p>
+        <p class="note" title='Usage'>
+          The RECOMMENDED format for this member is <code>"X.Y.Z"</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>"1.10.0"</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
+        </p>        
+        <p>
+          To <dfn>process the platform version's <code>target_platform_version</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |platform_version:ordered map|:
+        </p>
+        <ol class="algorithm">
+          <li>If |json|["target_platform_version"] does not [=map/exist=], or if the type of |json|["target_platform_version"] is not [=string=], return.</li>
+          <li>Set |platform_version|["target_platform_version"] to |json|["target_platform_version"].</li>
+        </ol>                 
+    </section>
+	
+    <section>
+      <h3><code>release_type</code> member</h3>
+
+        <p>
+          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>release_type</code></dfn> member is a [=string=] that Indicates the release type of the target API version required for running the application. The value can be CanaryN, BetaN, or Release. N represents a positive integer. (e.g., <code>"Beta1"</code>).
+        </p>
+       
+        <p>
+          To <dfn>process the platform version's <code>release_type</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |platform_version:ordered map|:
+        </p>
+        <ol class="algorithm">
+          <li>If |json|["release_type"] does not [=map/exist=], or if the type of |json|["release_type"] is not [=string=], return.</li>
+          <li>Set |platform_version|["release_type"] to |json|["release_type"].</li>
+        </ol>                 
+    </section>
+	
+
   </section>
 
   <section id="sec-permission-resources">
@@ -993,6 +1113,55 @@
       </ol>           
     </section>
   </section>
+
+
+
+  <section id="sec-version-resources">
+    <h2>MiniApp version resources</h2>
+    <p>
+      A <dfn data-lt="version resource|MiniApp version resources|MiniApp version resource's">MiniApp version resource</dfn> is an [=object=] that describes the version code and version name of a MiniApp.
+    </p>
+    <p>
+      The following members are defined under the scope of the [=MiniApp manifest=], addressing specific aspects of a [=version resource=].
+    </p>
+    <section>
+      <h3><code>version_code</code> member</h3>
+      <p>
+        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>version_code</code></dfn> member is a non-negative integer [=number=] that represents the version of a MiniApp. It is mainly used for enhancing the maintainability and security of MiniApp (e.g., compatibility among incremental versions). The <a><code>version_code</code></a> member aims at supporting the development and deployment process, and it is not usually displayed to the end-user.
+      </p>
+      <p>
+        To <dfn>process the version's <code>version_code</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |version:ordered map|:
+      </p>
+        <ol class="algorithm">
+          <li>If |json|["version_code"] does not [=map/exist=], or if the type of |json|["version_code"] is not [=number=], return failure.</li>
+          <li>Let |version:number| be a [=number=], initially 1.</li>
+          <li>If |json|["version_code"] is greater than 0, then: <br/>
+            Set |version| to |json|["version_code"].</li>
+          <li>Set |version|["version_code"] to |version|.</li>
+        </ol>           
+    </section>
+	
+    <section>
+      <h3><code>version_name</code> member</h3>
+      <p>
+        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>version_name</code></dfn> member is a [=string=] mainly used for describing information on the version of a MiniApp, playing an essential role in version control, MiniApp application, and platform compatibility. It is usually considered as the version that is shown publicly and displayed to the user.
+        </p>
+        <p class="note" title='Usage'>
+          The RECOMMENDED format for this member is <code>X.Y.Z</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>1.10.0</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
+        </p>
+        <p>
+          To <dfn>process the version's <code>version_name</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |version:ordered map|:
+        </p>
+        <ol class="algorithm">
+          <li>If |json|["version_name"] does not [=map/exist=], or if the type of |json|["version_name"] is not [=string=], return failure.</li>
+          <li>Set |version|["version_name"] to |json|["version_name"].</li>
+        </ol>           
+    </section>	
+
+  </section>
+
+
+
 
   <section id="sec-widget-resource-members">
     <h2>MiniApp widget resource members</h2>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     </style>
 
     <script async class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
-    <script defer src="https://w3c.github.io/miniapp/specs/script.js"></script>
+<!-- <script defer src="https://w3c.github.io/miniapp/specs/script.js"></script> -->
 
     <script class="remove">
         var respecConfig = {

--- a/index.html
+++ b/index.html
@@ -349,15 +349,15 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_platform_version</code></a></th>
-            <td> [=string=]  </td>
+            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_code</code></a></th>
+            <td> [=number=]  </td>
             <td>Yes</td>
             <td>
                 <span>Indicates the minimum platform version required for running the MiniApp. </span>
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_platform_version</code></a></th>
+            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_code</code></a></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -370,7 +370,7 @@
             <td> [=string=] </td>
             <td>No</td>
             <td>
-              <span>Indicates the release type of the target platform version required for running the application. The value can be CanaryN, BetaN, or Release. N represents a positive integer. 1) Canary: indicates a restrictedly released version. 2) Beta: indicates a publicly released beta version. 3)Release: indicates a publicly released official version. </span>
+              <span>Indicates the release type of the target platform version required for running the application. For example, it can be CanaryN, BetaN, or Release. N represents a positive integer. In these examples, 1) Canary: indicates a restrictedly released version. 2) Beta: indicates a publicly released beta version. 3)Release: indicates a publicly released official version. </span>
             </td>
           </tr>		  
         </tbody>
@@ -420,15 +420,15 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>version_code</code></a></th>
-            <td> [=string=]  </td>
+            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>code</code></a></th>
+            <td> [=number=]  </td>
             <td>Yes</td>
             <td>
                 <span>Version code</span>
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>version_name</code></a></th>
+            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>name</code></a></th>
             <td> [=string=] </td>
             <td>Yes</td>
             <td>
@@ -466,8 +466,8 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_platform_version</code></a></th>
-            <td> [=string=] </td>
+            <th scope="row"><a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_code</code></a></th>
+            <td> [=number=] </td>
             <td>No</td>
             <td>
               <span>Minimum platform version supported</span>
@@ -612,8 +612,8 @@
           "name": "MiniApp Demo",
           "short_name": "MiniApp",
           "version": {
-            "version_name": "1.0.1",
-            "version_code": 11
+            "name": "1.0.1",
+            "code": 11
           },
           "description": "A Simple MiniApp Demo",
           "icons": [
@@ -623,8 +623,8 @@
             }
           ],
           "platform_version":{
-            "min_platform_version": "1.0.0",
-            "target_platform_version": "1.2.1",
+            "min_code": "1",
+            "target_code": "2",
             "release_type": "Beta1"			
           },
           "pages": [
@@ -642,7 +642,7 @@
             {
               "name": "widget",
               "path": "widgets/index/index",
-              "min_platform_version": "2.0.0"
+              "min_code": "2"
             }
           ],
           "req_permissions": [
@@ -799,7 +799,7 @@
           <span><code>platform_version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>platform_version</code></dfn> member contains a <a>MiniApp platform version resource</a> [=object=] to represent the <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_platform_version</code></a>, <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_platform_version</code></a>, and <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>release_type</code></a>.
+          The [=MiniApp manifest's=] <dfn><code>platform_version</code></dfn> member contains a <a>MiniApp platform version resource</a> [=object=] to represent the <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_code</code></a>, <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_code</code></a>, and <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>release_type</code></a>.
         </p>
 
 
@@ -810,10 +810,10 @@
         <ol class="algorithm">
           <li>If |json|["platform_version"] does not [=map/exist=], or if the type of |json|["platform_version"] is not [=object=], return.</li>
           <li>Let |version:ordered map| be a new [=ordered map=].</li>
-          <li><a>Process the platform version's <code>min_platform_version</code> member</a> passing |json|["platform_version"] and |platform_version|.</li>
-          <li><a>Process the platform version's <code>target_platform_version</code> member</a> passing |json|["platform_version"] and |platform_version|.</li>         
+          <li><a>Process the platform version's <code>min_code</code> member</a> passing |json|["platform_version"] and |platform_version|.</li>
+          <li><a>Process the platform version's <code>target_code</code> member</a> passing |json|["platform_version"] and |platform_version|.</li>         
           <li><a>Process the platform version's <code>release_type</code> member</a> passing |json|["platform_version"] and |platform_version|.</li> 
-          <li>If |platform_version|["min_platform_version"] does not [=map/exist=], return failure.</li>  		  
+          <li>If |platform_version|["min_code"] does not [=map/exist=], return failure.</li>  		  
 		  <li>Set |manifest|["platform_version"] to |platform_version|.</li>
         </ol>             
       </section>
@@ -897,7 +897,7 @@
           <span><code>version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>version</code></dfn> member contains a <a>MiniApp version resource</a> [=object=] to represent the <dfn><code>version_code</code></dfn> and <dfn><code>version_name</code></dfn>.
+          The [=MiniApp manifest's=] <dfn><code>version</code></dfn> member contains a <a>MiniApp version resource</a> [=object=] to represent the <dfn><code>code</code></dfn> and <dfn><code>name</code></dfn>.
         </p>
 
 
@@ -908,8 +908,8 @@
         <ol class="algorithm">
           <li>If |json|["version"] does not [=map/exist=], or if the type of |json|["version"] is not [=object=], return.</li>
           <li>Let |version:ordered map| be a new [=ordered map=].</li>
-          <li><a>Process the version's <code>version_code</code> member</a> passing |json|["version"] and |version|.</li>
-          <li><a>Process the version's <code>version_name</code> member</a> passing |json|["version"] and |version|.</li>          
+          <li><a>Process the version's <code>code</code> member</a> passing |json|["version"] and |version|.</li>
+          <li><a>Process the version's <code>name</code> member</a> passing |json|["version"] and |version|.</li>          
 		  <li>Set |manifest|["version"] to |version|.</li>
         </ol>             
       </section>
@@ -952,7 +952,7 @@
               <li>Let |widget| be an [=ordered map=].</li>
               <li><a>Process the widget's <code>name</code> member</a> passing |item| and |widget|.</li>
               <li><a>Process the widget's <code>path</code> member</a> passing |item| and |widget|.</li>
-              <li><a>Process the widget's <code>min_platform_version</code> member</a> passing |item|, |manifest|, and |widget|.</li>
+              <li><a>Process the widget's <code>min_code</code> member</a> passing |item|, |manifest|, and |widget|.</li>
               <li>If |widget|["name"] does not [=map/exist=], or if |item|["path"] does not [=map/exist=], return failure.</li>              
               <li>[=list/Append=] |widget| to |widgets|.</li>
             </ol>
@@ -1022,38 +1022,34 @@
       The following members are defined under the scope of the [=MiniApp manifest=], addressing specific aspects of a [=platform version resource=].
     </p>
     <section>
-      <h3><code>min_platform_version</code> member</h3>
+      <h3><code>min_code</code> member</h3>
 
         <p>
-          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>min_platform_version</code></dfn> member is a [=string=] that indicates the minimum supported version of the MiniApp user agent's platform to ensure the regular operation of a MiniApp (e.g., <code>"1.0.0"</code>).
+          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>min_code</code></dfn> member is a non-negative integer [=number=] that indicates the minimum supported version of the MiniApp user agent's platform to ensure the regular operation of a MiniApp.
         </p>
-        <p class="note" title='Usage'>
-          The RECOMMENDED format for this member is <code>"X.Y.Z"</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>"1.10.0"</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
-        </p>        
+        
         <p>
-          To <dfn>process the platform version's <code>min_platform_version</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |platform_version:ordered map|:
+          To <dfn>process the platform version's <code>min_code</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |platform_version:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If |json|["min_platform_version"] does not [=map/exist=], or if the type of |json|["min_platform_version"] is not [=string=], return failure.</li>
-          <li>Set |platform_version|["min_platform_version"] to |json|["min_platform_version"].</li>
+          <li>If |json|["min_code"] does not [=map/exist=], or if the type of |json|["min_code"] is not [=number=], return failure.</li>
+          <li>Set |platform_version|["min_code"] to |json|["min_code"].</li>
         </ol>                 
     </section>
 	
     <section>
-      <h3><code>target_platform_version</code> member</h3>
+      <h3><code>target_code</code> member</h3>
 
         <p>
-          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>target_platform_version</code></dfn> member is a [=string=] that indicates the target supported version of the MiniApp user agent's platform to ensure the regular operation of a MiniApp (e.g., <code>"1.0.0"</code>).
+          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>target_code</code></dfn> member is a non-negative integer [=number=] that indicates the target supported version of the MiniApp user agent's platform to ensure the regular operation of a MiniApp.
         </p>
-        <p class="note" title='Usage'>
-          The RECOMMENDED format for this member is <code>"X.Y.Z"</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>"1.10.0"</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
-        </p>        
+     
         <p>
-          To <dfn>process the platform version's <code>target_platform_version</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |platform_version:ordered map|:
+          To <dfn>process the platform version's <code>target_code</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |platform_version:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If |json|["target_platform_version"] does not [=map/exist=], or if the type of |json|["target_platform_version"] is not [=string=], return.</li>
-          <li>Set |platform_version|["target_platform_version"] to |json|["target_platform_version"].</li>
+          <li>If |json|["target_code"] does not [=map/exist=], or if the type of |json|["target_code"] is not [=number=], return.</li>
+          <li>Set |platform_version|["target_code"] to |json|["target_code"].</li>
         </ol>                 
     </section>
 	
@@ -1061,7 +1057,7 @@
       <h3><code>release_type</code> member</h3>
 
         <p>
-          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>release_type</code></dfn> member is a [=string=] that indicates the release type of the target API version required for running the application. The value can be CanaryN, BetaN, or Release. N represents a positive integer. (e.g., <code>"Beta1"</code>).
+          The [=MiniApp platform version resource's=] <dfn data-dfn-for="MiniApp platform version resource"><code>release_type</code></dfn> member is a [=string=] that indicates the release type of the MiniApp user agent's target platform version that is required for running the application. For example, the value can be set to CanaryN, BetaN, or Release. N represents a positive integer, such as <code>"Beta1"</code>.
         </p>
        
         <p>
@@ -1125,36 +1121,36 @@
       The following members are defined under the scope of the [=MiniApp manifest=], addressing specific aspects of a [=version resource=].
     </p>
     <section>
-      <h3><code>version_code</code> member</h3>
+      <h3><code>code</code> member</h3>
       <p>
-        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>version_code</code></dfn> member is a non-negative integer [=number=] that represents the version of a MiniApp. It is mainly used for enhancing the maintainability and security of MiniApp (e.g., compatibility among incremental versions). The <a><code>version_code</code></a> member aims at supporting the development and deployment process, and it is not usually displayed to the end-user.
+        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>code</code></dfn> member is a non-negative integer [=number=] that represents the version of a MiniApp. It is mainly used for enhancing the maintainability and security of MiniApp (e.g., compatibility among incremental versions). The <a><code>code</code></a> member aims at supporting the development and deployment process, and it is not usually displayed to the end-user.
       </p>
       <p>
-        To <dfn>process the version's <code>version_code</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |version:ordered map|:
+        To <dfn>process the version's <code>code</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |version:ordered map|:
       </p>
         <ol class="algorithm">
-          <li>If |json|["version_code"] does not [=map/exist=], or if the type of |json|["version_code"] is not [=number=], return failure.</li>
+          <li>If |json|["code"] does not [=map/exist=], or if the type of |json|["code"] is not [=number=], return failure.</li>
           <li>Let |version:number| be a [=number=], initially 1.</li>
-          <li>If |json|["version_code"] is greater than 0, then: <br/>
-            Set |version| to |json|["version_code"].</li>
-          <li>Set |version|["version_code"] to |version|.</li>
+          <li>If |json|["code"] is greater than 0, then: <br/>
+            Set |version| to |json|["code"].</li>
+          <li>Set |version|["code"] to |version|.</li>
         </ol>           
     </section>
 	
     <section>
-      <h3><code>version_name</code> member</h3>
+      <h3><code>name</code> member</h3>
       <p>
-        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>version_name</code></dfn> member is a [=string=] mainly used for describing information on the version of a MiniApp, playing an essential role in version control, MiniApp application, and platform compatibility. It is usually considered as the version that is shown publicly and displayed to the user.
+        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>name</code></dfn> member is a [=string=] mainly used for describing information on the version of a MiniApp, playing an essential role in version control, MiniApp application, and platform compatibility. It is usually considered as the version that is shown publicly and displayed to the user.
         </p>
         <p class="note" title='Usage'>
           The RECOMMENDED format for this member is <code>X.Y.Z</code>, where <code>X</code>, <code>Y</code>, and <code>Z</code> are non-negative integer values (e.g., <samp>1.10.0</samp>), as specified in <cite>Semantic Versioning</cite> [[SEMANTIC-VERSIONING]].
         </p>
         <p>
-          To <dfn>process the version's <code>version_name</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |version:ordered map|:
+          To <dfn>process the version's <code>name</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |version:ordered map|:
         </p>
         <ol class="algorithm">
-          <li>If |json|["version_name"] does not [=map/exist=], or if the type of |json|["version_name"] is not [=string=], return failure.</li>
-          <li>Set |version|["version_name"] to |json|["version_name"].</li>
+          <li>If |json|["name"] does not [=map/exist=], or if the type of |json|["name"] is not [=string=], return failure.</li>
+          <li>Set |version|["name"] to |json|["name"].</li>
         </ol>           
     </section>	
 
@@ -1200,21 +1196,21 @@
       </ol>
     </section>
     <section>
-      <h3><code>min_platform_version</code> member</h3>
+      <h3><code>min_code</code> member</h3>
       <p>
-        The optional [=MiniApp widget resource's=] <dfn data-dfn-for="MiniApp widget resource"><code>min_platform_version</code></dfn> member is a [=string=] that indicates the minimum platform version supported for a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-widget">MiniApp widget</a>.
+        The optional [=MiniApp widget resource's=] <dfn data-dfn-for="MiniApp widget resource"><code>min_code</code></dfn> member is a [=number=] that indicates the minimum platform version supported for a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-widget">MiniApp widget</a>.
       </p>
       <p class="note" title='Usage'>
-        Since Widget APIs and MiniApp APIs may differ, the declaration of the minimum version of the platform may be different. Thus, if the widgets member omits <a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_platform_version</code></a> explicitly, the user agent will consider the same requirement as the specified in the <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_platform_version</code></a> member in the <a><code>platform_version</code></a> object.
+        Since Widget APIs and MiniApp APIs may differ, the declaration of the minimum version of the platform may be different. Thus, if the widgets member omits <a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_code</code></a> explicitly, the user agent will consider the same requirement as the specified in the <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_code</code></a> member in the <a><code>platform_version</code></a> object.
         </p>
       </p>
       <p>
-        To <dfn>process the widget's <code>min_platform_version</code> member</dfn>, given [=object=] |json:JSON|, [=ordered map=] |widget:ordered map| and [=ordered map=] |manifest:ordered map|:
+        To <dfn>process the widget's <code>min_code</code> member</dfn>, given [=object=] |json:JSON|, [=ordered map=] |widget:ordered map| and [=ordered map=] |manifest:ordered map|:
       </p>
       <ol class="algorithm">
-        <li>Set |widget|["min_platform_version"] to |manifest|["min_platform_version"].</li>        
-        <li>If |json|["min_platform_version"] does not [=map/exist=], or if the type of |json|["min_platform_version"] is not [=string=], return.</li>
-        <li>Set |widget|["min_platform_version"] to |json|["min_platform_version"].</li>
+        <li>Set |widget|["min_code"] to |manifest|["min_code"].</li>        
+        <li>If |json|["min_code"] does not [=map/exist=], or if the type of |json|["min_code"] is not [=string=], return.</li>
+        <li>Set |widget|["min_code"] to |json|["min_code"].</li>
       </ol>      
     </section>
   </section>
@@ -1512,7 +1508,7 @@
     <section>
         <h2>Transparency</h2>
         <p>
-          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, <a><code>version_name</code></a>, <a><code>description</code></a>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
+          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, <a><code>name</code></a>, <a><code>description</code></a>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
         </p>
     </section>
   </section>


### PR DESCRIPTION
Modified the version_code, version_name, and min_platform_version member. 
For version_code and version_name member, proposed to add a version object, version, that contains these two members. It can help to group the members of similar functionality, makes the manifest more clear.
For min_platform_version, proposed to add a platform_version object, that contains min_platform_version, target_platform_version, and release_type. 
-The min_platform_version indicates the minimum platform version required for running the MiniApp.
-The target_platform_version indicates the target platform version required for running the MiniApp.
-The release_type indicates the release type of the target platform version required for running the application. The value can be CanaryN, BetaN, or Release. N represents a positive integer. 1) Canary: indicates a restrictedly released version. 2) Beta: indicates a publicly released beta version. 3)Release: indicates a publicly released official version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MichaelWangzitao/miniapp-manifest/pull/21.html" title="Last updated on Jun 21, 2021, 8:38 AM UTC (bcb2bdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/21/dc0de01...MichaelWangzitao:bcb2bdb.html" title="Last updated on Jun 21, 2021, 8:38 AM UTC (bcb2bdb)">Diff</a>