### PR TITLE
Added two attributes to support the selection of color mode and device types

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,22 @@
               <span>Window style</span>
             </td>
           </tr>
+          <tr>
+            <th scope="row"><a><code>color_mode</code></a></th>
+            <td> [=string=] </td>
+            <td>No</td>
+            <td>
+              <span>MiniApp color mode</span>
+            </td>
+          </tr>
+          <tr>
+            <th scope="row"><a><code>device_type</code></a></th>
+            <td> [=array=] </td>
+            <td>No</td>
+            <td>
+              <span>Indicates the type of devices on which the MiniApp can run.</span>
+            </td>
+          </tr>			  
         </tbody>
       </table>
 
@@ -583,7 +599,13 @@
               "name": "system.permission.CAMERA",
               "reason": "To scan a QR code"
             }
-          ]
+          ]，
+          "color_mode": "light",
+          "device_type": [
+             "phone",
+             "tv",
+             "car"
+          ]		  
         }
       </pre>
     </section>
@@ -933,6 +955,43 @@
           <li>Set |manifest|["window"] to |window|.</li>
         </ol>             
       </section>
+      <section>
+        <h3>
+          <span><code>color_mode</code> member</span>
+        </h3>
+        <p>
+          The [=MiniApp manifest's=] <dfn><code>color_mode</code></dfn> member indicates the color mode of the MiniApp. It provides three modes to be selected, "dark", "light", and "auto". That can help users to switch between them according to their habits. When it is set to "auto", the MiniApp's theme color automatically adapts to the system theme color.
+        </p>
+        <p>
+          To <dfn>process the <code>color_mode</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
+        </p>
+        <ol class="algorithm">
+          <li>If |json|["color_mode"] does not [=map/exist=], or if the type of |json|["color_mode"] is not [=string=], return.</li>
+          <li>Set |manifest|["color_mode"] to |json|["color_mode"].</li>
+        </ol>
+      </section>
+      <section>
+        <h3>
+          <span><code>device_type</code> member</span>
+        </h3>
+        <p>
+          The [=MiniApp manifest's=] <dfn><code>device_type</code></dfn> member is an array of strings that indicates the type of devices on which the MiniApp can run. The value can be phone (smartphones), tablet (tablets), tv (smart TVs), car (head units), wearable (wearables), iot (IoT devices).
+        </p>
+        <p>
+          To <dfn>process the <code>device_type</code> member</dfn>, given [=object=] |json:JSON| and [=ordered map=] |manifest:ordered map|:
+        </p>
+        <ol class="algorithm">
+          <li>If |json|["device_type"] does not [=map/exist=], or if the type of |json|["device_type"] is not [=list=], return.</li>
+          <li>Let |device_type:list| be a new empty [=list=].</li>
+          <li>[=list/For each=] |item:string| of |json|["device_type"]:
+            <ol>
+              <li>If the type of |item| is not [=string=], return.</li>             
+              <li>[=list/Append=] |device_type| to |device_type|.</li>
+            </ol>
+          </li>
+          <li>Set |manifest|["device_type"] to |device_type|.</li>
+        </ol>        
+      </section>	  
     </section>
     <section id="processing" data-cite="APPMANIFEST">
       <h3>Processing the manifest</h3>
@@ -952,6 +1011,8 @@
         <li><a>Process the <code>version_name</code> member</a> passing |json| and |manifest|.</li>
         <li><a>Process the <code>widgets</code> member</a> passing |json| and |manifest|.</li>
         <li><a>Process the <code>window</code> member</a> passing |json| and |manifest|.</li>
+        <li><a>Process the <code>color_mode</code> member</a> passing |json| and |manifest|.</li>	
+        <li><a>Process the <code>device_type</code> member</a> passing |json| and |manifest|.</li>			
       </ol>      
     </section>
   </section>


### PR DESCRIPTION
Propose to adding two attributes: color_mode and device_type.
For color_mode, it allows developers to define the default theme color, e,.g. light, dark, or automatically adjust with the system. Can be used for branding, improved visibility for people with poor vision and strong light, and better use of MiniApp in low light environments.
For device_type, it allows developers to specify the type of devices on which the MiniApp can be installed to support cross-platform capabilities of the same app, reducing repeated development. The device types may include mobile phones, tablets, vehicle-mounted devices, wearable devices, TVs, and IoT devices.