### PR TITLE
Remove the reference to #8

### DIFF
--- a/index.html
+++ b/index.html
@@ -1517,7 +1517,6 @@
             if |json|["orientation"] doesn't [=list/contain=] one of the [=orientation values=], return.</li>
         <li>Set |window|["orientation"] to |json|["orientation"].</li>
       </ol>
-      <div class="issue" data-number="8"></div>
     </section>
   </section>
 


### PR DESCRIPTION
Remove the reference to #8 since it's closed now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/pull/34.html" title="Last updated on Sep 27, 2021, 3:18 AM UTC (0e83a1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/34/dc9f63a...0e83a1d.html" title="Last updated on Sep 27, 2021, 3:18 AM UTC (0e83a1d)">Diff</a>