### PR TITLE
Pages member clarification and example fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -880,7 +880,7 @@
           A <dfn data-lt="page route|page routes">MiniApp page route</dfn> is the relative path and filename of a MiniApp Page.
         </p> 
         <p>
-          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/component/mypage</samp>).
+          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/pages/mypage</samp>).
         </p>
         <p>
           The first item in the <a><code>pages</code></a> [=list=] defines the homepage of a MiniApp.

--- a/index.html
+++ b/index.html
@@ -874,16 +874,13 @@
           <span><code>pages</code> member</span>
         </h3>
         <p>
-            The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a [=page route=].
+            The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
         </p> 
         <p>
-          A <dfn data-lt="page route|page routes">MiniApp page route</dfn> is the relative path and filename of a MiniApp Page.
-        </p> 
-        <p>
-          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/pages/mypage</samp>).
+          A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>/pages/mypage</samp> or <samp>/pages/mypage.html</samp>).
         </p>
         <p>
-          The first item in the <a><code>pages</code></a> [=list=] defines the homepage of a MiniApp.
+          The first item in the <a><code>pages</code></a> [=list=] defines the homepage or entry point of a MiniApp.
         </p>
         <div class="note" title="Usage">
           <p>


### PR DESCRIPTION
Closes #35

This change:

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

- Fixing the example for alignment with the Packaging specification. 
- The text clarifies that the user can either omit the extension of a page or include the extension of the main component.
