### PR TITLE
Section on accessibility considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -877,7 +877,7 @@
             The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
         </p> 
         <p>
-          A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>/pages/mypage</samp> or <samp>/pages/mypage.html</samp>).
+          A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>pages/mypage</samp> or <samp>pages/mypage.html</samp>).
         </p>
         <p>
           The first item in the <a><code>pages</code></a> [=list=] defines the homepage or entry point of a MiniApp.

--- a/index.html
+++ b/index.html
@@ -1548,7 +1548,7 @@
   </section>
 
   <section>
-    <h2>Accessibility Considerations</h2>
+    <h2>Accessibility considerations</h2>
     <p>
       This document specifies a set of metadata, enabling developers and publishers to describe and configure the behavior and appearance of MiniApps. Some manifest attributes, like `color_scheme` and the `window` resource members, aim user agents to generate customized user interfaces to enable interaction between the user and the MiniApp.
     </p>
@@ -1563,7 +1563,7 @@
     </p>
   </section>
   <section>
-    <h2>Security and Privacy Considerations</h2>
+    <h2>Security and privacy considerations</h2>
     <section>
         <h2>Content constraint</h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -1547,7 +1547,7 @@
     </p>
   </section>
 
-  <section>
+  <section class="informative">
     <h2>Accessibility considerations</h2>
     <p>
       This document specifies a set of metadata, enabling developers and publishers to describe and configure the behavior and appearance of MiniApps. Some manifest attributes, like `color_scheme` and the `window` resource members, aim user agents to generate customized user interfaces to enable interaction between the user and the MiniApp.

--- a/index.html
+++ b/index.html
@@ -880,7 +880,7 @@
           A <dfn data-lt="page route|page routes">MiniApp page route</dfn> is the relative path and filename of a MiniApp Page.
         </p> 
         <p>
-          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/component/mypage</samp>).
+          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/pages/mypage</samp>).
         </p>
         <p>
           The first item in the <a><code>pages</code></a> [=list=] defines the homepage of a MiniApp.

--- a/index.html
+++ b/index.html
@@ -874,16 +874,13 @@
           <span><code>pages</code> member</span>
         </h3>
         <p>
-            The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a [=page route=].
+            The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
         </p> 
         <p>
-          A <dfn data-lt="page route|page routes">MiniApp page route</dfn> is the relative path and filename of a MiniApp Page.
-        </p> 
-        <p>
-          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/pages/mypage</samp>).
+          A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>/pages/mypage</samp> or <samp>/pages/mypage.html</samp>).
         </p>
         <p>
-          The first item in the <a><code>pages</code></a> [=list=] defines the homepage of a MiniApp.
+          The first item in the <a><code>pages</code></a> [=list=] defines the homepage or entry point of a MiniApp.
         </p>
         <div class="note" title="Usage">
           <p>

--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@
     </p>
   </section>
   <section>
-    <h2>Security and privacy considerations</h2>
+    <h2>Security and Privacy Considerations</h2>
     <section>
         <h2>Content constraint</h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -719,7 +719,10 @@
         </dl>
         <p class="note" title="Processing the `icons` member">
           When [=processing a MiniApp manifest=], the <a href="https://www.w3.org/TR/appmanifest/#dfn-process-image-resources" data-link-type="dfn">process image resources</a> algorithm is used to process the <code>icons</code> member, according to the [[APPMANIFEST]] specification.
-        </p>        
+        </p>
+        <p class="note" title="Accessibility considerations">
+          Developers are strongly encouraged to add a `label` unless the [=image resource=]’s accessible name can be inferred from an external label in its context.
+        </p>
       </section>      
       <section>
         <h3>

--- a/index.html
+++ b/index.html
@@ -1548,6 +1548,21 @@
   </section>
 
   <section>
+    <h2>Accessibility Considerations</h2>
+    <p>
+      This document specifies a set of metadata, enabling developers and publishers to describe and configure the behavior and appearance of MiniApps. Some manifest attributes, like `color_scheme` and the `window` resource members, aim user agents to generate customized user interfaces to enable interaction between the user and the MiniApp.
+    </p>
+    <p>
+      The <a><code>icons</code></a> member allows developers to describe the visual and iconic representation of a MiniApp in the platform and operating system. Here, the platform should adequately communicate with the platform accessibility services to represent the images, also using the alternative textual descriptions (e.g., <a><code>icon</code></a>'s <a href="https://www.w3.org/TR/image-resource/#dfn-label" data-link-type="dfn"><code>label</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a> and <a><code>short_name</code></a>) to enhance accessibility (i.e., icons in the home screen of the device, listing in app directories, and app configuration).
+    </p>
+    <p>
+      User agents must ensure that the user interface is perceivable and operable, so they should take special consideration when processing the members that affect the user agent interface and the rendered content, like with the setup of color schemes and themes (i.e., <a><code>color_scheme</code></a>, <a data-link-for="MiniApp window resource" data-link-type="dfn"><code>background_color</code></a>, <a><code>background_text_style</code></a>, <a><code>navigation_bar_background_color</code></a>, <a><code>navigation_bar_background_color</code></a>, <a><code>navigation_bar_text_style</code></a>, and <a><code>navigation_style</code></a>) and other configuration settings like <a><code>orientation</code></a>, <a><code>fullscreen</code></a>, <a><code>enable_pull_down_refresh</code></a>, and <a><code>on_reach_bottom_distance</code></a>.
+    </p>
+    <p>
+      User agents interpreting this manifest should help users orient within and control windows and viewports. They should also provide alternative views addressing the different usage scenarios through the advanced use of the `device_type` member and extending the manifest with vendor-specific members to enhance accessibility. Thus, MiniApp user agents and platforms should provide mechanisms for configuring user stylesheets, themes and customize the display and interaction with the application, complying with the applicable specifications and conventions, in particular the [[[UAAG20]]].
+    </p>
+  </section>
+  <section>
     <h2>Security and Privacy Considerations</h2>
     <section>
         <h2>Content constraint</h2>


### PR DESCRIPTION
Closes #32 

This change:

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

Commit message:

- New section with accessibility considerations focused on the manifest members that affect app user interface or behavior.
- New note on `icons.label` as it is recommended in the original media resource specification.
- Recommendations for the user agents to implement UAAG.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-manifest/pull/37.html" title="Last updated on Jan 17, 2022, 11:16 AM UTC (3af7679)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/37/a23b8a3...espinr:3af7679.html" title="Last updated on Jan 17, 2022, 11:16 AM UTC (3af7679)">Diff</a>