### PR TITLE
Fix ReSpec warnings: definitions not linked

### DIFF
--- a/index.html
+++ b/index.html
@@ -1054,6 +1054,7 @@
           <li><a href="https://www.w3.org/TR/appmanifest/#dfn-process-a-color-member" data-link-type="dfn">Process a color member</a> passing |json|["window"], |window| and "navigation_bar_background_color".</li>
           <li><a>Process the window's <code>navigation_bar_text_style</code> member</a> passing |json|["window"] and |window|.</li>
           <li><a>Process the window's <code>navigation_bar_title_text</code> member</a> passing |json|["window"] and |window|.</li>
+          <li><a>Process the window's <code>navigation_style</code> member</a> passing |json|["window"] and |window|.</li>
           <li><a>Process the window's <code>on_reach_bottom_distance</code> member</a> passing |json|["window"] and |window|.</li>
           <li><a>Process the window's <code>orientation</code> member</a> passing |json|["window"] and |window|.</li>
           <li><a>Process the window's <code>auto_design_width</code> member</a> passing |json|["window"] and |window|.</li>
@@ -1415,15 +1416,15 @@
     <section>
       <h3><code>navigation_bar_text_style</code> member</h3>
       <p>
-        <span>The <dfn><code>navigation_bar_text_style</code></dfn> member is a [=string=] that indicates the text color of the navigation bar title.</span>
+        <span>The <dfn><code>navigation_bar_text_style</code></dfn> member is a [=string=] that indicates the text color of the navigation bar title (i.e., "[=text style values/`white`=]" or "[=text style values/`black`=]").</span>
       </p>
       <p>
         This member MUST contain one of the following <dfn>text style values</dfn>:  
       </p>
       <dl>
-        <dt>"<dfn data-dfn-for="text style values">white</dfn>" (default)</dt>
+        <dt>"<dfn data-dfn-for="text style values"><code>white</code></dfn>" (default)</dt>
         <dd>For white text color.</dd>
-        <dt>"<dfn data-dfn-for="text style values">black</dfn>" </dt>
+        <dt>"<dfn data-dfn-for="text style values"><code>black</code></dfn>"</dt>
         <dd>For black text color.</dd>
       </dl>
       <p>
@@ -1453,15 +1454,15 @@
     <section>
       <h3><code>navigation_style</code> member</h3>
       <p>
-        The <dfn><code>navigation_style</code></dfn> member is a [=string=] that specifies the style of the navigation bar.
+        The <dfn><code>navigation_style</code></dfn> member is a [=string=] that specifies the style of the navigation bar (i.e., "[=navigation style values/`default`=]" or "[=navigation style values/`custom`=]").
       </p>
       <p>
         This member MUST contain one of the following <dfn>navigation style values</dfn>: 
       </p>
       <dl>
-        <dt>"<dfn data-dfn-for="navigation style values">default</dfn>" (default)</dt>
+        <dt>"<dfn data-dfn-for="navigation style values"><code>default</code></dfn>" (default)</dt>
         <dd>For applying the style by default.</dd>
-        <dt>"<dfn data-dfn-for="navigation style values">custom</dfn>"</dt>
+        <dt>"<dfn data-dfn-for="navigation style values"><code>custom</code></dfn>"</dt>
         <dd>For applying a customized navigation bar.</dd>
       </dl>
       <p>

--- a/index.html
+++ b/index.html
@@ -877,7 +877,7 @@
             The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
         </p> 
         <p>
-          A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>/pages/mypage</samp> or <samp>/pages/mypage.html</samp>).
+          A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>pages/mypage</samp> or <samp>pages/mypage.html</samp>).
         </p>
         <p>
           The first item in the <a><code>pages</code></a> [=list=] defines the homepage or entry point of a MiniApp.

--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,8 @@
           <li>Let |window:ordered map| be a new [=ordered map=] «[ "auto_design_width" → false, "background_color" → "#ffffff", "background_text_style" → "dark", "design_width" → 750, "enable_pull_down_refresh" → false, "fullscreen" → "false", "navigation_bar_background_color" → "#000000", "navigation_bar_text_style" → "white", "navigation_bar_title_text" → "default", "on_reach_bottom_distance" → 50, "orientation" → "portrait" ]».</li>
           <li><a>Process the window's <code>auto_design_width</code> member</a> passing |json|["window"] and |window|.</li>
           <li><a href="https://www.w3.org/TR/appmanifest/#dfn-process-a-color-member" data-link-type="dfn">Process a color member</a> passing |json|["window"], |window| and "background_color".</li>
-          <li><a>Process the window's <code>design_width</code> member</a> passing |json|["window"] and |window|.</li>
+          <li><a>Process the window's <code>background_text_style</code> member</a> passing |json|["window"] and |window|.</li>
+          <li><a>Process the window's <code>design_width</code> member</a> passing |json|["window"] and |window|
           <li><a>Process the window's <code>enable_pull_down_refresh</code> member</a> passing |json|["window"] and |window|.</li>
           <li><a>Process the window's <code>fullscreen</code> member</a> passing |json|["window"] and |window|.</li>
           <li><a href="https://www.w3.org/TR/appmanifest/#dfn-process-a-color-member" data-link-type="dfn">Process a color member</a> passing |json|["window"], |window| and "navigation_bar_background_color".</li>

--- a/index.html
+++ b/index.html
@@ -1588,10 +1588,10 @@
     </p>
     <div class="issue">
       <p>
-        Still to define the security policy to fetch icon images described in the manifest. The Web App Manifest <a href="https://www.w3.org/TR/appmanifest/#content-security-policy">is based</a> on the `img-src` directive [[CSP3]], associated with the manifest's owner `Document`. However, this solution is not enough for the MiniApp manifest since the manifest does not always have HTTP headers associated. 
+        Still to define the security policy to fetch icon images described in the manifest. The Web App Manifest <a href="https://www.w3.org/TR/appmanifest/#content-security-policy">is based</a> on the `img-src` directive [[CSP3]], associated with the manifest's owner `Document`. However, this solution is not valid for the MiniApp manifest since the manifest does not always have HTTP headers associated. 
       </p>
       <p>
-        What happens when `file:`, `data:`, or `blob:` URLs are passed? 
+        What happens when `file:`, `data:`, `javascript:`, or `blob:` URLs are passed? 
       </p>
     </div>
   </section>

--- a/index.html
+++ b/index.html
@@ -877,7 +877,7 @@
           <span><code>pages</code> member</span>
         </h3>
         <p>
-            The [=MiniApp manifest's=] <code><dfn>pages</dfn></code> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
+            The [=MiniApp manifest's=] <code><dfn data-export="">pages</dfn></code> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
         </p> 
         <p>
           A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>pages/mypage</samp> or <samp>pages/mypage.html</samp>).

--- a/index.html
+++ b/index.html
@@ -126,26 +126,26 @@
       </p>
       <ul>
         <li>
-          <a><code>app_id</code></a>
+          <code>[=app_id=]</code>
         </li>
         <li>
-          <a><code>icons</code></a>
+          <code>[=icons=]</code>
         </li>
         <li>
-          <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>
+          <code>[=MiniApp manifest/name=]</code>
         </li>
         <li>
-          <a><code>pages</code></a>
+          <code>[=pages=]</code>
         </li>
         <li>
-          <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>platform_version</code></a>
+          <code>[=MiniApp manifest/platform_version=]</code>
         </li>
         <li>
-          <a><code>version</code></a>
+          <code>[=version=]</code>
         </li>  
       </ul>
       <p>
-          Each [=image resource=] object within the [=MiniApp manifest's=] <a><code>icons</code></a> member MUST contain:
+          Each [=image resource=] object within the [=MiniApp manifest's=] <code>[=icons=]</code> member MUST contain:
       </p>
       <ul>
         <li>
@@ -153,22 +153,22 @@
         </li>
       </ul>
       <p>
-        A [=MiniApp manifest=] MAY contain a <a><code>widgets</code></a> member at its root. This member MUST contain an array ([=list=]) of <a>MiniApp widget resources</a>. Each [=MiniApp widget resource=] object MUST contain the following members:
+        A [=MiniApp manifest=] MAY contain a <code>[=widgets=]</code> member at its root. This member MUST contain an array ([=list=]) of [=MiniApp widget resources=]. Each [=MiniApp widget resource=] object MUST contain the following members:
       </p>
       <ul>
         <li>
-         <a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>name</code></a>
+         <code>[=MiniApp widget resource/name=]</code>
         </li>
         <li>
-         <a><code>path</code></a>
+         <code>[=path=]</code>
         </li>
       </ul>
       <p>
-        A [=MiniApp manifest=] MAY contain a <a><code>req_permissions</code></a> member at its root. This member MUST contain an array ([=list=]) of <a>MiniApp permission resources</a>. Each [=MiniApp permission resource=] object MUST contain the following member:
+        A [=MiniApp manifest=] MAY contain a <code>[=req_permissions=]</code> member at its root. This member MUST contain an array ([=list=]) of [=MiniApp permission resources=]. Each [=MiniApp permission resource=] object MUST contain the following member:
       </p>
       <ul>
         <li>
-         <a data-link-for="MiniApp permission resource" data-link-type="dfn"><code>name</code></a>
+         <code>[=MiniApp permission resource/name=]</code>
         </li>
       </ul>
       <p>MiniApp user agents may implement vendor-specific extensions of the [=manifest=], supporting optional members.</p>   
@@ -191,7 +191,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a><code>app_id</code></a></th>
+            <th scope="row"><code>[=app_id=]</code></th>
             <td> [=string=] </td>
             <td>Yes</td>
             <td>
@@ -199,7 +199,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>color_scheme</code></a></th>
+            <th scope="row"><code>[=color_scheme=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -207,7 +207,7 @@
             </td>
           </tr>		
           <tr>
-            <th scope="row"><a><code>description</code></a></th>
+            <th scope="row"><code>[=description=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -215,7 +215,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>device_type</code></a></th>
+            <th scope="row"><code>[=device_type=]</code></th>
             <td> [=list=] </td>
             <td>No</td>
             <td>
@@ -223,7 +223,7 @@
             </td>
           </tr> 		
           <tr>
-            <th scope="row"><a><code>dir</code></a></th>
+            <th scope="row"><code>[=dir=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -231,7 +231,7 @@
             </td>
           </tr>
           <tr data-cite="IMAGE-RESOURCE">
-            <th scope="row"><a><code>icons</code></a></th>
+            <th scope="row"><code>[=icons=]</code></th>
             <td> [=image resource=] [=list=] </td>
             <td>Yes</td>
             <td>
@@ -239,7 +239,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>lang</code></a></th>
+            <th scope="row"><code>[=lang=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -247,7 +247,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a></th>
+            <th scope="row"><code>[=MiniApp manifest/name=]</code></th>
             <td> [=string=] </td>
             <td>Yes</td>
             <td>
@@ -255,7 +255,7 @@
             </td>
           </tr>          
           <tr>
-            <th scope="row"><a><code>pages</code></a></th>
+            <th scope="row"><code>[=pages=]</code></th>
             <td> [=list=] </td>
             <td>Yes</td>
             <td>
@@ -263,21 +263,21 @@
             </td>
           </tr>          
           <tr>
-            <th scope="row"><a data-link-for="MiniApp manifest" data-link-type="dfn"><code>platform_version</code></a></th>
-            <td> <a>platform version resource</a> </td>
+            <th scope="row"><code>[=MiniApp manifest/platform_version=]</code></th>
+            <td> [=platform version resource=] </td>
 			      <td>Yes</td>
             <td>
               <span>Platform version supported</span>
             </td>
           </tr>
           <tr>
-              <th scope="row"><a><code>req_permissions</code></a></th>              
-              <td> <a>permission resource</a> [=list=] </td>
+              <th scope="row"><code>[=req_permissions=]</code></th>              
+              <td> [=permission resource=] [=list=] </td>
               <td>No</td>
               <td> <span>Required permissions</span></td>
           </tr>          
           <tr>
-            <th scope="row"><a><code>short_name</code></a></th>
+            <th scope="row"><code>[=short_name=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -285,8 +285,8 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>version</code></a></th>
-            <td> <a>version resource</a> </td>
+            <th scope="row"><code>[=version=]</code></th>
+            <td> [=version resource=] </td>
             <td>Yes</td>
             <td>
               <span>MiniApp version</span>
@@ -294,15 +294,15 @@
           </tr>          
 
           <tr>
-            <th scope="row"><a><code>widgets</code></a></th>
-            <td> <a>widget resource</a> [=list=] </td>
+            <th scope="row"><code>[=widgets=]</code></th>
+            <td> [=widget resource=] [=list=] </td>
             <td>No</td>
             <td> <span>MiniApp widgets</span>
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>window</code></a></th>
-            <td> <a>window resource</a> </td>
+            <th scope="row"><code>[=window=]</code></th>
+            <td> [=window resource=] </td>
             <td>No</td>
             <td>
               <span>Window style</span>
@@ -312,7 +312,7 @@
       </table>
 
       <table class="members">
-        <caption>Members of [=image resource=] objects<br/>(<a><code>icons</code></a> [=list=])</caption>
+        <caption>Members of [=image resource=] objects<br/>(<code>[=icons=]</code> [=list=])</caption>
         <thead>
           <tr>
             <th scope="col">Member</th>
@@ -350,7 +350,7 @@
       </table>
 
       <table class="members">
-        <caption>Members of [=platform version resource=] objects<br/>(<a><code>platform_version</code></a> [=ordered map=])</caption>
+        <caption>Members of [=platform version resource=] objects<br/>(<code>[=platform_version=]</code> [=ordered map=])</caption>
         <thead>
           <tr>
             <th scope="col">Member</th>
@@ -361,7 +361,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_code</code></a></th>
+            <th scope="row"><code>[=MiniApp platform version resource/min_code=]</code></th>
             <td> number  </td>
             <td>Yes</td>
             <td>
@@ -369,7 +369,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>release_type</code></a></th>
+            <th scope="row"><code>[=MiniApp platform version resource/release_type=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -377,7 +377,7 @@
             </td>
           </tr>          
           <tr>
-            <th scope="row"><a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_code</code></a></th>
+            <th scope="row"><code>[=MiniApp platform version resource/target_code=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -388,7 +388,7 @@
       </table>
 
       <table class="members">
-        <caption>Members of [=permission resource=] objects<br/>(<a><code>req_permissions</code></a> [=list=])</caption>
+        <caption>Members of [=permission resource=] objects<br/>(<code>[=req_permissions=]</code> [=list=])</caption>
         <thead>
           <tr>
             <th scope="col">Member</th>
@@ -399,7 +399,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp permission resource" data-link-type="dfn"><code>name</code></a></th>
+            <th scope="row"><code>[=MiniApp permission resource/name=]</code></th>
             <td> [=string=] </td>
             <td>Yes</td>
             <td>
@@ -407,7 +407,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>reason</code></a></th>
+            <th scope="row"><code>[=reason=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -418,7 +418,7 @@
       </table>
 
       <table class="members">
-        <caption>Members of [=version resource=] objects<br/>(<a><code>version</code></a> [=ordered map=])</caption>
+        <caption>Members of [=version resource=] objects<br/>(<code>[=version=]</code> [=ordered map=])</caption>
         <thead>
           <tr>
             <th scope="col">Member</th>
@@ -429,7 +429,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>code</code></a></th>
+            <th scope="row"><code>[=MiniApp version resource/code=]</code></th>
             <td> number  </td>
             <td>Yes</td>
             <td>
@@ -437,7 +437,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp version resource" data-link-type="dfn"><code>name</code></a></th>
+            <th scope="row"><code>[=MiniApp version resource/name=]</code></th>
             <td> [=string=] </td>
             <td>Yes</td>
             <td>
@@ -448,7 +448,7 @@
       </table>
 
       <table class="members">
-        <caption>Members of [=widget resource=] objects<br/>(<a><code>widgets</code></a> [=list=])</caption>
+        <caption>Members of [=widget resource=] objects<br/>(<code>[=widgets=]</code> [=list=])</caption>
         <thead>
           <tr>
             <th scope="col">Member</th>
@@ -459,7 +459,7 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_code</code></a></th>
+            <th scope="row"><code>[=MiniApp widget resource/min_code=]</code></th>
             <td> number </td>
             <td>No</td>
             <td>
@@ -467,7 +467,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>name</code></a></th>
+            <th scope="row"><code>[=MiniApp widget resource/name=]</code></th>
             <td> [=string=] </td>
             <td>Yes</td>
             <td>
@@ -475,7 +475,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>path</code></a></th>
+            <th scope="row"><code>[=path=]</code></th>
             <td> [=string=] </td>
             <td>Yes</td>
             <td>
@@ -486,7 +486,7 @@
       </table>
 
       <table class="members">
-        <caption>Members of [=window resource=] objects<br/>(<a><code>window</code></a> [=ordered map=])</caption>
+        <caption>Members of [=window resource=] objects<br/>(<code>[=window=]</code> [=ordered map=])</caption>
         <thead>
           <tr>
             <th scope="col">Member</th>
@@ -497,15 +497,15 @@
         </thead>
         <tbody>
           <tr>
-            <th scope="row"><a><code>auto_design_width</code></a></th>
+            <th scope="row"><code>[=auto_design_width=]</code></th>
             <td> [=boolean=]  </td>
             <td>No</td>
             <td>
-                <span>Enables/disables auto-calculation of page's <a><code>design_width</code></a> </span>
+                <span>Enables/disables auto-calculation of page's <code>[=design_width=]</code> </span>
             </td>
           </tr>
           <tr>
-            <th scope="row"><a data-link-for="MiniApp window resource" data-link-type="dfn"><code>background_color</code></a></th>
+            <th scope="row"><code>[=MiniApp window resource/background_color=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -513,7 +513,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>background_text_style</code></a></th>
+            <th scope="row"><code>[=background_text_style=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -521,7 +521,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>design_width</code></a></th>
+            <th scope="row"><code>[=design_width=]</code></th>
             <td> number  </td>
             <td>No</td>
             <td>
@@ -529,7 +529,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>enable_pull_down_refresh</code></a></th>
+            <th scope="row"><code>[=enable_pull_down_refresh=]</code></th>
             <td> [=boolean=] </td>
             <td>No</td>
             <td>
@@ -537,7 +537,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>fullscreen</code></a></th>
+            <th scope="row"><code>[=fullscreen=]</code></th>
             <td> [=boolean=]  </td>
             <td>No</td>
             <td>
@@ -545,7 +545,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>navigation_bar_background_color</code></a></th>
+            <th scope="row"><code>[=navigation_bar_background_color=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -553,7 +553,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>navigation_bar_text_style</code></a></th>
+            <th scope="row"><code>[=navigation_bar_text_style=]</code></th>
             <td> [=string=]  </td>
             <td>No</td>
             <td>
@@ -561,7 +561,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>navigation_bar_title_text</code></a></th>
+            <th scope="row"><code>[=navigation_bar_title_text=]</code></th>
             <td> [=string=]  </td>
             <td>No</td>
             <td>
@@ -569,7 +569,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>navigation_style</code></a></th>
+            <th scope="row"><code>[=navigation_style=]</code></th>
             <td> [=string=] </td>
             <td>No</td>
             <td>
@@ -577,7 +577,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>on_reach_bottom_distance</code></a></th>
+            <th scope="row"><code>[=on_reach_bottom_distance=]</code></th>
             <td> number </td>
             <td>No</td>
             <td>
@@ -585,7 +585,7 @@
             </td>
           </tr>
           <tr>
-            <th scope="row"><a><code>orientation</code></a></th>
+            <th scope="row"><code>[=orientation=]</code></th>
             <td> [=string=]  </td>
             <td>No</td>
             <td>
@@ -681,9 +681,9 @@
       <section>
         <h3><code>dir</code> member</h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>dir</code></dfn> member, while specifying the base direction of the <a>localizable members</a> of the [=manifest=], also specifies
+          The [=MiniApp manifest's=] <code><dfn>dir</dfn></code> member, while specifying the base direction of the [=localizable members=] of the [=manifest=], also specifies
           the default base text direction of the whole MiniApp.</p> 
-        <p>The <a><code>dir</code></a> member's value can be set to one of the <a href="https://www.w3.org/TR/appmanifest/#dfn-text-directions">text-directions</a> as specified in [[APPMANIFEST]]. The text-direction values are the following:</p>
+        <p>The <code>[=dir=]</code> member's value can be set to one of the <a href="https://www.w3.org/TR/appmanifest/#dfn-text-directions">text-directions</a> as specified in [[APPMANIFEST]]. The text-direction values are the following:</p>
         <dl>
           <dt><a href="https://www.w3.org/TR/appmanifest/#dfn-ltr" data-type="dfn" data-link-type="dfn"><code>"ltr"</code></a></dt>
           <dd>Left-to-right text.</dd>
@@ -701,7 +701,7 @@
           <span><code>icons</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>icons</code></dfn> member describes images that serve as iconic representations of MiniApps. This member is a [=list=] of [=image resource=] [=ordered maps=].
+          The [=MiniApp manifest's=] <code><dfn>icons</dfn></code> member describes images that serve as iconic representations of MiniApps. This member is a [=list=] of [=image resource=] [=ordered maps=].
         </p>
         <p>As specified in [[IMAGE-RESOURCE]], an [=image resource=] consists of:</p>
         <dl>
@@ -729,7 +729,7 @@
           <span><code>lang</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>lang</code></dfn> member, while specifying the primary language of the <a>localizable members</a>, also specifies
+          The [=MiniApp manifest's=] <code><dfn>lang</dfn></code> member, while specifying the primary language of the [=localizable members=], also specifies
           the primary language of the whole MiniApp. This member is a [=string=] in the form of a <a href="https://www.w3.org/TR/appmanifest/#dfn-language-tag" data-link-type="dfn">language tag</a>, a string that matches the production of a <code>Language-Tag</code> [[BCP47]], as defined in [[APPMANIFEST]].
         </p>
         <p class="note" title="Processing the `lang` member">
@@ -752,7 +752,7 @@
           <span><code>short_name</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>short_name</code></dfn> member provides a concise and easy-to-read name for a MiniApp. It can be used when there is insufficient space to display the full MiniApp name provided in <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>.
+          The [=MiniApp manifest's=] <code><dfn>short_name</dfn></code> member provides a concise and easy-to-read name for a MiniApp. It can be used when there is insufficient space to display the full MiniApp name provided in <code>[=MiniApp manifest/name=]</code>.
         </p>
         <p class="note" title="Processing the `short_name` member">
           When [=processing a MiniApp manifest=], the <a href="https://www.w3.org/TR/appmanifest/#dfn-process-a-text-member" data-link-type="dfn">process a text member</a> algorithm is used to process the <code>short_name</code> member, according to the [[APPMANIFEST]] specification.
@@ -770,7 +770,7 @@
           <span><code>description</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>description</code></dfn> member provides a textual description for the MiniApp representing the purpose of the web application in natural language, as defined in [[MANIFEST-APP-INFO]]
+          The [=MiniApp manifest's=] <code><dfn>description</dfn></code> member provides a textual description for the MiniApp representing the purpose of the web application in natural language, as defined in [[MANIFEST-APP-INFO]]
         </p>
         <p>
           To <dfn>process the <code>description</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
@@ -792,10 +792,10 @@
           <span><code>app_id</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>app_id</code></dfn> member is a [=string=] that identifies the MiniApp univocally. This member is mainly used for package management, and it supports the update and release process of MiniApp versioning.
+          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp univocally. This member is mainly used for package management, and it supports the update and release process of MiniApp versioning.
         </p>
         <p>
-          The format of <a><code>app_id</code></a> is RECOMMENDED to be a [=string=] defined by the following rule:
+          The format of <code>[=app_id=]</code> is RECOMMENDED to be a [=string=] defined by the following rule:
         </p>
         <pre class="abnf">
           appIdRule = name *("." name)
@@ -818,7 +818,7 @@
           <span><code>color_scheme</code> member</span>
         </h3>
         <p>
-          The optional [=MiniApp manifest's=] <dfn><code>color_scheme</code></dfn> member is a [=string=] that indicates the preferred color scheme of a MiniApp (i.e., "[=color_scheme/`auto`=]", "[=color_scheme/`light`=], or "[=color_scheme/`dark`=]"), overriding other configuration members of the <a>window resource</a> object, including <a data-link-for="MiniApp window resource" data-link-type="dfn"><code>background_color</code></a>, <a><code>background_text_style</code></a>, <a><code>navigation_bar_text_style</code></a>, and <a><code>navigation_bar_title_text</code></a>.
+          The optional [=MiniApp manifest's=] <code><dfn>color_scheme</dfn></code> member is a [=string=] that indicates the preferred color scheme of a MiniApp (i.e., "[=color_scheme/`auto`=]", "[=color_scheme/`light`=], or "[=color_scheme/`dark`=]"), overriding other configuration members of the [=window resource=] object, including <code>[=MiniApp window resource/background_color=]</code>, <code>[=background_text_style=]</code>, <code>[=navigation_bar_text_style=]</code>, and <code>[=navigation_bar_title_text=]</code>.
         </p>
         <p>
           This member MUST contain one of the following <dfn>color scheme values</dfn>:  
@@ -849,7 +849,7 @@
           <span><code>device_type</code> member</span>
         </h3>
         <p>
-          The optional [=MiniApp manifest's=] <dfn><code>device_type</code></dfn> member is a [=list=] of [=strings=] that indicates the type of devices on which the MiniApp is intended to run. The values of this member inform user agents if the MiniApp has been designed to properly run on specific platforms like smartphones, smart TVs, car head units, wearables, and other devices.
+          The optional [=MiniApp manifest's=] <code><dfn>device_type</dfn></code> member is a [=list=] of [=strings=] that indicates the type of devices on which the MiniApp is intended to run. The values of this member inform user agents if the MiniApp has been designed to properly run on specific platforms like smartphones, smart TVs, car head units, wearables, and other devices.
         </p>
         <p>
           This member is used for device compatibility verification during the initialization process. By checking its value, the user agent decides if the MiniApp is suitable to be run on the platform in terms of compatibility of UI components, CSS support, and APIs. MiniApp user agents decide how to implement the platform's behavior if the verification process fails (e.g., stopping the initialization phase and refusing the installation or installing the MiniApp but rejecting the execution). 
@@ -877,20 +877,20 @@
           <span><code>pages</code> member</span>
         </h3>
         <p>
-            The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
+            The [=MiniApp manifest's=] <code><dfn>pages</dfn></code> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
         </p> 
         <p>
           A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>pages/mypage</samp> or <samp>pages/mypage.html</samp>).
         </p>
         <p>
-          The first item in the <a><code>pages</code></a> [=list=] defines the homepage or entry point of a MiniApp.
+          The first item in the <code>[=pages=]</code> [=list=] defines the homepage or entry point of a MiniApp.
         </p>
         <div class="note" title="Usage">
           <p>
-            For compatibility with the Web platform, it is RECOMMENDED to use <a><code>pages</code></a> along with the Web application manifest's <a href="https://www.w3.org/TR/appmanifest/#start_url-member" data-link-type="dfn"><code>start_url</code></a> and <a href="https://www.w3.org/TR/appmanifest/#scope-member" data-link-type="dfn"><code>scope</code></a> members. These members will be set with the following values:
+            For compatibility with the Web platform, it is RECOMMENDED to use <code>[=pages=]</code> along with the Web application manifest's <a href="https://www.w3.org/TR/appmanifest/#start_url-member" data-link-type="dfn"><code>start_url</code></a> and <a href="https://www.w3.org/TR/appmanifest/#scope-member" data-link-type="dfn"><code>scope</code></a> members. These members will be set with the following values:
           </p>
           <ul>
-            <li><a href="https://www.w3.org/TR/appmanifest/#start_url-member" data-link-type="dfn">start_url</a> SHOULD be set with the same value of the first item in the <a><code>pages</code></a> member; and</li>
+            <li><a href="https://www.w3.org/TR/appmanifest/#start_url-member" data-link-type="dfn">start_url</a> SHOULD be set with the same value of the first item in the <code>[=pages=]</code> member; and</li>
             <li><a href="https://www.w3.org/TR/appmanifest/#scope-member" data-link-type="dfn">scope</a> SHOULD be set with the value <code>"."</code>.</li>
           </ul>
         </div>
@@ -916,7 +916,7 @@
           <span><code>platform_version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>platform_version</code></dfn> member contains a <a>MiniApp platform version resource</a> [=ordered map=] for describing the minimum requirements and intended platform version to run a MiniApp, including <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_code</code></a>, <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>target_code</code></a>, and <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>release_type</code></a>.
+          The [=MiniApp manifest's=] <code><dfn>platform_version</dfn></code> member contains a [=MiniApp platform version resource=] [=ordered map=] for describing the minimum requirements and intended platform version to run a MiniApp, including <code>[=MiniApp platform version resource/min_code=]</code>, <code>[=MiniApp platform version resource/target_code=]</code>, and <code>[=MiniApp platform version resource/release_type=]</code>.
         </p>
         <p>
           To <dfn>process the <code>platform_version</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
@@ -936,10 +936,10 @@
           <span><code>req_permissions</code> member</span>
         </h3>
         <p>
-            The optional [=MiniApp manifest's=] <dfn><code>req_permissions</code></dfn> member is a [=list=] of [=MiniApp permission resources=] [=ordered map=].
+            The optional [=MiniApp manifest's=] <code><dfn>req_permissions</dfn></code> member is a [=list=] of [=MiniApp permission resources=] [=ordered map=].
         </p> 
         <p> 
-          Each <a>MiniApp permission resource</a> declares a request for using a concrete system feature (e.g., access to device's location, user contacts, sensors, and camera) required for the proper execution of a MiniApp.
+          Each [=MiniApp permission resource=]</code> declares a request for using a concrete system feature (e.g., access to device's location, user contacts, sensors, and camera) required for the proper execution of a MiniApp.
         </p>
         <p>
           To <dfn>process the <code>req_permissions</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
@@ -960,7 +960,7 @@
           <li>Set |manifest|["req_permissions"] to |permissions|.</li>
         </ol>        
         <p class="note" title="Protection of user's privacy">
-          User agents will ask for the user's consent to protect their privacy during access to these specific features. This information in the <a><code>req_permissions</code></a> member may be used by app stores or hosting platforms to filter MiniApps according to the user's preferences, privacy policy, or device capabilities. 
+          User agents will ask for the user's consent to protect their privacy during access to these specific features. This information in the <code>[=req_permissions=]</code> member may be used by app stores or hosting platforms to filter MiniApps according to the user's preferences, privacy policy, or device capabilities. 
         </p>
       </section> 
 
@@ -969,7 +969,7 @@
           <span><code>version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>version</code></dfn> member contains a <a>MiniApp version resource</a> [=ordered map=] to represent the <a data-link-for="MiniApp version resource" data-link-type="dfn"><code>code</code></a> and <a data-link-for="MiniApp version resource" data-link-type="dfn"><code>name</code></a>.
+          The [=MiniApp manifest's=] <code><dfn>version</dfn></code> member contains a [=MiniApp version resource=]</code> [=ordered map=] to represent the <code>[=MiniApp version resource/code=]</code> and <code>[=MiniApp version resource/name=]</code>.
         </p>
         <p>
           To <dfn>process the <code>version</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
@@ -989,7 +989,7 @@
           <span><code>widgets</code> member</span>
         </h3>
         <p>
-            The optional [=MiniApp manifest's=] <dfn><code>widgets</code></dfn> member is a [=list=] of [=MiniApp widget resources=] that are a part of a MiniApp.
+            The optional [=MiniApp manifest's=] <code><dfn>widgets</dfn></code> member is a [=list=] of [=MiniApp widget resources=] that are a part of a MiniApp.
         </p>
         <p>
             A <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-package">MiniApp Package</a> MAY include <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> and Widgets concurrently.
@@ -998,16 +998,16 @@
             A widget, as part of a MiniApp, applies some of the members of the [=MiniApp manifest=], including:
         </p> 
         <ul>
-          <li><a><code>dir</code></a>;</li>
-          <li><a><code>lang</code></a>;</li>
-          <li><a><code>app_id</code></a>;</li>
-          <li><a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>;</li>
-          <li><a><code>short_name</code></a>;</li>
-          <li><a><code>icons</code></a>;</li>
-          <li><a><code>version</code></a></li>
+          <li><code>[=dir=]</code>;</li>
+          <li><code>[=lang=]</code>;</li>
+          <li><code>[=app_id=]</code>;</li>
+          <li><code>[=MiniApp manifest/name=]</code>;</li>
+          <li><code>[=short_name=]</code>;</li>
+          <li><code>[=icons=]</code>;</li>
+          <li><code>[=version=]</code></li>
         </ul>
         <p>
-          However, a widget also has its exclusive fields as defined in the <a>MiniApp widget resource</a>.
+          However, a widget also has its exclusive fields as defined in the [=MiniApp widget resource=]</code>.
         </p>
         <p>
           To <dfn>process the <code>widgets</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
@@ -1034,10 +1034,10 @@
           <span><code>window</code> member</span>
         </h3>
         <p>
-          The optional [=MiniApp manifest's=] <dfn><code>window</code></dfn> member contains a <a>MiniApp window resource</a> [=ordered map=] to describe the look and feel of a MiniApp frame, including the styles of the status bar, navigation bar, title, background colors, among other visual configuration elements.
+          The optional [=MiniApp manifest's=] <code><dfn>window</dfn></code> member contains a [=MiniApp window resource=]</code> [=ordered map=] to describe the look and feel of a MiniApp frame, including the styles of the status bar, navigation bar, title, background colors, among other visual configuration elements.
         </p>
         <p>
-            The <a><code>window</code></a> object members inherit the text direction and language configuration from the <a><code>dir</code></a> and <a><code>lang</code></a> members at the root of the [=MiniApp manifest=].
+            The <code>[=window=]</code> object members inherit the text direction and language configuration from the <code>[=dir=]</code> and <code>[=lang=]</code> members at the root of the [=MiniApp manifest=].
         </p>
         <p>
           To <dfn>process the <code>window</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
@@ -1171,7 +1171,7 @@
     <section>
       <h3><code>reason</code> member</h3>
       <p>
-        The optional [=MiniApp permission resource's=] <dfn><code>reason</code></dfn> member is a [=string=] that indicates the reason given to request the feature specified in the <a data-link-type="dfn" data-link-for="MiniApp permission resource"><code>name</code></a> attribute.
+        The optional [=MiniApp permission resource's=] <code><dfn>reason</dfn></code> member is a [=string=] that indicates the reason given to request the feature specified in the <a data-link-type="dfn" data-link-for="MiniApp permission resource"><code>name</code></a> attribute.
       </p>
       <p>
         To <dfn>process the permission resource's <code>reason</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |permission:ordered map|:
@@ -1197,7 +1197,7 @@
     <section>
       <h3><code>code</code> member</h3>
       <p>
-        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>code</code></dfn> member is a non-negative integer number that represents the version of a MiniApp. It is mainly used for enhancing the maintainability and security of MiniApp (e.g., compatibility among incremental versions). The <a><code>code</code></a> member aims at supporting the development and deployment process, and it is not usually displayed to the end-user.
+        The [=MiniApp version resource's=] <dfn data-dfn-for="MiniApp version resource"><code>code</code></dfn> member is a non-negative integer number that represents the version of a MiniApp. It is mainly used for enhancing the maintainability and security of MiniApp (e.g., compatibility among incremental versions). The <code>[=code=]</code> member aims at supporting the development and deployment process, and it is not usually displayed to the end-user.
       </p>
       <p>
         To <dfn>process the version's <code>code</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |version:ordered map|:
@@ -1252,7 +1252,7 @@
     <section>
       <h3><code>path</code> member</h3>
       <p>
-        The [=MiniApp widget resource's=] <dfn>path</dfn> member is a [=relative-url string=] that defines the corresponding  [=page route=] of a widget, represented as in the <a><code>pages</code></a> [=list=].
+        The [=MiniApp widget resource's=] <dfn>path</dfn> member is a [=relative-url string=] that defines the corresponding  [=page route=] of a widget, represented as in the <code>[=pages=]</code> [=list=].
       </p>
       <p>
         To <dfn>process the widget's <code>path</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |widget:ordered map|:
@@ -1270,7 +1270,7 @@
         The optional [=MiniApp widget resource's=] <dfn data-dfn-for="MiniApp widget resource"><code>min_code</code></dfn> member is a number that indicates the minimum platform version supported for a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-widget">MiniApp widget</a>.
       </p>
       <p class="note" title='Usage'>
-        Since Widget APIs and MiniApp APIs may differ, the declaration of the minimum version of the platform may be different. Thus, if the widgets member omits <a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>min_code</code></a> explicitly, the user agent will consider the same requirement as the specified in the <a data-link-for="MiniApp platform version resource" data-link-type="dfn"><code>min_code</code></a> member in the <a><code>platform_version</code></a> object.
+        Since Widget APIs and MiniApp APIs may differ, the declaration of the minimum version of the platform may be different. Thus, if the widgets member omits <code>[=MiniApp widget resource/min_code=]</code> explicitly, the user agent will consider the same requirement as the specified in the <code>[=MiniApp platform version resource/min_code=]</code> member in the <code>[=platform_version=]</code> object.
         </p>
       </p>
       <p>
@@ -1295,7 +1295,7 @@
     <section>
       <h3><code>auto_design_width</code> member</h3>
       <p>
-        The <dfn><code>auto_design_width</code></dfn> member is a [=boolean=] that indicates whether the <a><code>design_width</code></a> of the page is auto-calculated by the user agent. When <a><code>auto_design_width</code></a> is <code>true</code>, the value of <a><code>design_width</code></a> is ignored. In this case, the system's baseline width is automatically determined according to the pixel density of the screen.
+        The <code><dfn>auto_design_width</dfn></code> member is a [=boolean=] that indicates whether the <code>[=design_width=]</code> of the page is auto-calculated by the user agent. When <code>[=auto_design_width=]</code> is <code>true</code>, the value of <code>[=design_width=]</code> is ignored. In this case, the system's baseline width is automatically determined according to the pixel density of the screen.
       </p>
       <p>
         Value by default: <code>false</code>.
@@ -1326,7 +1326,7 @@
     <section data-cite="CSS-COLOR-4 MEDIAQUERIES-5">
       <h3><code>background_text_style</code> member</h3>
       <p>
-        <span>The <dfn><code>background_text_style</code></dfn> member is a [=string=] that specifies the background text style, indicating a light or dark color theme (i.e., "[=background text style values/`light`=]" or "[=background text style values/`dark`=]").</span>
+        <span>The <code><dfn>background_text_style</dfn></code> member is a [=string=] that specifies the background text style, indicating a light or dark color theme (i.e., "[=background text style values/`light`=]" or "[=background text style values/`dark`=]").</span>
       </p>
       <p>
         This member supports the values of <a data-xref-type="css-descriptor" data-xref-for="@media">prefers-color-scheme</a> and MUST contain one of the following <dfn>background text style values</dfn>:  
@@ -1350,7 +1350,7 @@
     <section>
       <h3><code>design_width</code> member</h3>
       <p>
-        The <dfn><code>design_width</code></dfn> member is a number that indicates the baseline width of the page design in <a data-cite="css-values">pixel unit</a>. It is  used for visually adjusting the page components.
+        The <code><dfn>design_width</dfn></code> member is a number that indicates the baseline width of the page design in <a data-cite="css-values">pixel unit</a>. It is  used for visually adjusting the page components.
       </p>
       <p>
         The value is a non-negative integer and the value by default is <code>750</code>.
@@ -1367,7 +1367,7 @@
     <section>
       <h3><code>enable_pull_down_refresh</code> member</h3>
       <p>
-        The <dfn><code>enable_pull_down_refresh</code></dfn> member is a [=boolean=] that specifies if the <code>pull-to-refresh</code> event is enabled during the interaction with the MiniApp.
+        The <code><dfn>enable_pull_down_refresh</dfn></code> member is a [=boolean=] that specifies if the <code>pull-to-refresh</code> event is enabled during the interaction with the MiniApp.
       </p>
       <p>
         Value by default: <code>false</code>.
@@ -1384,7 +1384,7 @@
     <section>
       <h3><code>fullscreen</code> member</h3>
       <p>
-        The <dfn><code>fullscreen</code></dfn> member is a [=boolean=] that indicates if the MiniApp is shown in full-screen display mode.
+        The <code><dfn>fullscreen</dfn></code> member is a [=boolean=] that indicates if the MiniApp is shown in full-screen display mode.
       </p>
       <p class="note" title='Usage'>
         When this member takes the <code>true</code> value, it is equivalent to the <a href="https://www.w3.org/TR/appmanifest/#dfn-fullscreen" data-link-type="dfn"><code>fullscreen</code> value on the application manifest's <a href="https://www.w3.org/TR/appmanifest/#dfn-display" data-link-type="dfn"><code>display</code></a> member. When it takes <code>false</code> as value, it is equivalent to <a href="https://www.w3.org/TR/appmanifest/#dfn-minimal-ui" data-link-type="dfn"><code>minimal-ui</code></a>.
@@ -1404,7 +1404,7 @@
     <section data-cite="CSS-COLOR-4 CSS-SYNTAX-3">
       <h3><code>navigation_bar_background_color</code> member</h3>
       <p>
-        <span>The <dfn><code>navigation_bar_background_color</code></dfn> member is a [=string=] that specifies the color of the background of the navigation bar of a MiniApp.</span>
+        <span>The <code><dfn>navigation_bar_background_color</dfn></code> member is a [=string=] that specifies the color of the background of the navigation bar of a MiniApp.</span>
       </p>
       <p>This member supports [=sRGB=] colors.</p>
       <p>Value by default: <code>"#000000"</code>.</p>
@@ -1416,7 +1416,7 @@
     <section>
       <h3><code>navigation_bar_text_style</code> member</h3>
       <p>
-        <span>The <dfn><code>navigation_bar_text_style</code></dfn> member is a [=string=] that indicates the text color of the navigation bar title (i.e., "[=text style values/`white`=]" or "[=text style values/`black`=]").</span>
+        <span>The <code><dfn>navigation_bar_text_style</dfn></code> member is a [=string=] that indicates the text color of the navigation bar title (i.e., "[=text style values/`white`=]" or "[=text style values/`black`=]").</span>
       </p>
       <p>
         This member MUST contain one of the following <dfn>text style values</dfn>:  
@@ -1440,7 +1440,7 @@
     <section>
       <h3><code>navigation_bar_title_text</code> member</h3>
       <p>
-        The <dfn><code>navigation_bar_title_text</code></dfn> member is a [=string=] that specifies the title of the navigation bar of a MiniApp.
+        The <code><dfn>navigation_bar_title_text</dfn></code> member is a [=string=] that specifies the title of the navigation bar of a MiniApp.
       </p>
       <p>
         To <dfn>process the window's <code>navigation_bar_title_text</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |window:ordered map|:
@@ -1454,7 +1454,7 @@
     <section>
       <h3><code>navigation_style</code> member</h3>
       <p>
-        The <dfn><code>navigation_style</code></dfn> member is a [=string=] that specifies the style of the navigation bar (i.e., "[=navigation style values/`default`=]" or "[=navigation style values/`custom`=]").
+        The <code><dfn>navigation_style</dfn></code> member is a [=string=] that specifies the style of the navigation bar (i.e., "[=navigation style values/`default`=]" or "[=navigation style values/`custom`=]").
       </p>
       <p>
         This member MUST contain one of the following <dfn>navigation style values</dfn>: 
@@ -1481,7 +1481,7 @@
     <section>
       <h3><code>on_reach_bottom_distance</code> member</h3>
       <p>
-        The <dfn><code>on_reach_bottom_distance</code></dfn> member is a number that defines the vertical offset from the bottom of the window required to trigger a page pull-up event. Values for this member are non-negative integers expressed in <a data-cite="css-values">pixel unit</a>.
+        The <code><dfn>on_reach_bottom_distance</dfn></code> member is a number that defines the vertical offset from the bottom of the window required to trigger a page pull-up event. Values for this member are non-negative integers expressed in <a data-cite="css-values">pixel unit</a>.
       </p>
       <p>
         Value by default: <code>50</code>.
@@ -1499,7 +1499,7 @@
     <section>
       <h3><code>orientation</code> member</h3>
       <p>
-        The <dfn><code>orientation</code></dfn> member is a [=string=] that specifies the configuration of the screen orientation for the MiniApp. 
+        The <code><dfn>orientation</dfn></code> member is a [=string=] that specifies the configuration of the screen orientation for the MiniApp. 
       </p>
       <p>
         This member supports the <dfn>orientation values</dfn>: <code>"portrait"</code> and <code>"landscape"</code> defined in {{OrientationLockType}} [[SCREEN-ORIENTATION]].
@@ -1525,17 +1525,17 @@
   <section id="sec-localizable-members">
     <h2>Localizable members</h2>
     <p>
-        A <dfn data-lt="localizable members">localizable member</dfn> is a [=manifest=] member whose content may be adapted to specific linguistic, geographical, and cultural aspects. These localizable members share the <a href="https://www.w3.org/TR/appmanifest/#dfn-language-tag" data-link-type="dfn">language tag</a> (<a><code>lang</code></a>) and display direction (<a><code>dir</code></a>) defined at manifest's root.
+        A <dfn data-lt="localizable members">localizable member</dfn> is a [=manifest=] member whose content may be adapted to specific linguistic, geographical, and cultural aspects. These localizable members share the <a href="https://www.w3.org/TR/appmanifest/#dfn-language-tag" data-link-type="dfn">language tag</a> (<code>[=lang=]</code>) and display direction (<code>[=dir=]</code>) defined at manifest's root.
     </p>
     <p>
       The following members are [=localizable members=]:
     </p>
     <ul>
-        <li><a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a></li>
-        <li><a><code>short_name</code></a></li>
-        <li><a><code>description</code></a></li>
-        <li>[=MiniApp window resource's=] <a><code>navigation_bar_title_text</code></a></li>
-        <li>[=MiniApp widget resource's=] <a data-link-for="MiniApp widget resource" data-link-type="dfn"><code>name</code></a></li>
+        <li><code>[=MiniApp manifest/name=]</code></li>
+        <li><code>[=short_name=]</code></li>
+        <li><code>[=description=]</code></li>
+        <li>[=MiniApp window resource's=] <code>[=navigation_bar_title_text=]</code></li>
+        <li>[=MiniApp widget resource's=] <code>[=MiniApp widget resource/name=]</code></li>
     </ul>
   </section>
 
@@ -1555,10 +1555,10 @@
       This document specifies a set of metadata, enabling developers and publishers to describe and configure the behavior and appearance of MiniApps. Some manifest attributes, like `color_scheme` and the `window` resource members, aim user agents to generate customized user interfaces to enable interaction between the user and the MiniApp.
     </p>
     <p>
-      The <a><code>icons</code></a> member allows developers to describe the visual and iconic representation of a MiniApp in the platform and operating system. Here, the platform should adequately communicate with the platform accessibility services to represent the images, also using the alternative textual descriptions (e.g., <a><code>icon</code></a>'s <a href="https://www.w3.org/TR/image-resource/#dfn-label" data-link-type="dfn"><code>label</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a> and <a><code>short_name</code></a>) to enhance accessibility (i.e., icons in the home screen of the device, listing in app directories, and app configuration).
+      The <code>[=icons=]</code> member allows developers to describe the visual and iconic representation of a MiniApp in the platform and operating system. Here, the platform should adequately communicate with the platform accessibility services to represent the images, also using the alternative textual descriptions (e.g., <code>[=icon=]</code>'s <a href="https://www.w3.org/TR/image-resource/#dfn-label" data-link-type="dfn"><code>label</code></a>, <code>[=MiniApp manifest/name</code></a> and <code>[=short_name=]</code>) to enhance accessibility (i.e., icons in the home screen of the device, listing in app directories, and app configuration).
     </p>
     <p>
-      User agents must ensure that the user interface is perceivable and operable, so they should take special consideration when processing the members that affect the user agent interface and the rendered content, like with the setup of color schemes and themes (i.e., <a><code>color_scheme</code></a>, <a data-link-for="MiniApp window resource" data-link-type="dfn"><code>background_color</code></a>, <a><code>background_text_style</code></a>, <a><code>navigation_bar_background_color</code></a>, <a><code>navigation_bar_background_color</code></a>, <a><code>navigation_bar_text_style</code></a>, and <a><code>navigation_style</code></a>) and other configuration settings like <a><code>orientation</code></a>, <a><code>fullscreen</code></a>, <a><code>enable_pull_down_refresh</code></a>, and <a><code>on_reach_bottom_distance</code></a>.
+      User agents must ensure that the user interface is perceivable and operable, so they should take special consideration when processing the members that affect the user agent interface and the rendered content, like with the setup of color schemes and themes (i.e., <code>[=color_scheme=]</code>, <code>[=MiniApp window resource/background_color=]</code>, <code>[=background_text_style=]</code>, <code>[=navigation_bar_background_color=]</code>, <code>[=navigation_bar_background_color=]</code>, <code>[=navigation_bar_text_style=]</code>, and <code>[=navigation_style=]</code>) and other configuration settings like <code>[=orientation=]</code>, <code>[=fullscreen=]</code>, <code>[=enable_pull_down_refresh=]</code>, and <code>[=on_reach_bottom_distance=]</code>.
     </p>
     <p>
       User agents interpreting this manifest should help users orient within and control windows and viewports. They should also provide alternative views addressing the different usage scenarios through the advanced use of the `device_type` member and extending the manifest with vendor-specific members to enhance accessibility. Thus, MiniApp user agents and platforms should provide mechanisms for configuring user stylesheets, themes and customize the display and interaction with the application, complying with the applicable specifications and conventions, in particular the [[[UAAG20]]].
@@ -1577,10 +1577,10 @@
     <section>
         <h2>Local resource access</h2>
         <p>
-          Members like <a><code>icons</code></a>, <a><code>pages</code></a>, and <a><code>widgets</code></a> contain paths referring to local resources on the hosting platform. Implementors and the hosting platform should check the validity of those paths to prevent illegal access out of the scope of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-package">MiniApp Package</a>. On the other hand, the MiniApp itself (e.g., using scripting code) may provide mechanisms to access external resources either on the hosting platform or on remote websites (e.g., through a URI). In this case, the hosting platform is responsible for providing a clear indication to an end-user about such a context switch.
+          Members like <code>[=icons=]</code>, <code>[=pages=]</code>, and <code>[=widgets=]</code> contain paths referring to local resources on the hosting platform. Implementors and the hosting platform should check the validity of those paths to prevent illegal access out of the scope of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-package">MiniApp Package</a>. On the other hand, the MiniApp itself (e.g., using scripting code) may provide mechanisms to access external resources either on the hosting platform or on remote websites (e.g., through a URI). In this case, the hosting platform is responsible for providing a clear indication to an end-user about such a context switch.
         </p>
 	      <p>
-         Additionally, the <a><code>req_permissions</code></a> member provides a specific means to control the access the local software, hardware, and data resources on the user's device. User's consent should be asked when it comes to privacy-related or high-level privileged resources.
+         Additionally, the <code>[=req_permissions=]</code> member provides a specific means to control the access the local software, hardware, and data resources on the user's device. User's consent should be asked when it comes to privacy-related or high-level privileged resources.
         </p>
     </section>
 
@@ -1592,7 +1592,7 @@
     <section>
         <h2>Transparency</h2>
         <p>
-          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, and <a><code>description</code></a>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
+          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <code>[=app_id=]</code>, <code>[=MiniApp manifest/name=]</code>, <code>[=short_name=]</code>, <code>[=icons=]</code>, and <code>[=description=]</code>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
         </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -1548,7 +1548,7 @@
   </section>
 
   <section>
-    <h2>Accessibility Considerations</h2>
+    <h2>Accessibility considerations</h2>
     <p>
       This document specifies a set of metadata, enabling developers and publishers to describe and configure the behavior and appearance of MiniApps. Some manifest attributes, like `color_scheme` and the `window` resource members, aim user agents to generate customized user interfaces to enable interaction between the user and the MiniApp.
     </p>
@@ -1563,7 +1563,7 @@
     </p>
   </section>
   <section>
-    <h2>Security and Privacy Considerations</h2>
+    <h2>Security and privacy considerations</h2>
     <section>
         <h2>Content constraint</h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -1588,7 +1588,10 @@
     </p>
     <div class="issue">
       <p>
-        Still to define the security policy to fetch icon images described in the manifest. The Web App Manifest <a href="https://www.w3.org/TR/appmanifest/#content-security-policy">is based</a> on the `img-src` directive [[CSP3]], associated with the manifest's owner `Document`. However, this solution is not valid for the MiniApp manifest since the manifest does not always have HTTP headers associated. 
+        Still to define the security policy to fetch icon images described in the manifest. The Web App Manifest <a href="https://www.w3.org/TR/appmanifest/#content-security-policy">is based</a> on the `img-src` directive [[CSP3]], associated with the manifest's owner `Document`. However, this solution is not valid for the MiniApp manifest because it does not have HTTP headers associated.
+      </p>
+      <p>
+        Should we define a new MiniApp manifest member to indicate the Content Security Policy (CSP) to control the resources that a MiniApp can fetch or execute? This should be also explained in the Security Considerations of the Packaging specification.
       </p>
       <p>
         What happens when `file:`, `data:`, `javascript:`, or `blob:` URLs are passed? 

--- a/index.html
+++ b/index.html
@@ -818,17 +818,17 @@
           <span><code>color_scheme</code> member</span>
         </h3>
         <p>
-          The optional [=MiniApp manifest's=] <dfn><code>color_scheme</code></dfn> member is a [=string=] that indicates the preferred color scheme of a MiniApp, overriding other configuration members of the <a>window resource</a> object, including <a data-link-for="MiniApp window resource" data-link-type="dfn"><code>background_color</code></a>, <a><code>background_text_style</code></a>, <a><code>navigation_bar_text_style</code></a>, and <a><code>navigation_bar_title_text</code></a>.
+          The optional [=MiniApp manifest's=] <dfn><code>color_scheme</code></dfn> member is a [=string=] that indicates the preferred color scheme of a MiniApp (i.e., "[=color_scheme/`auto`=]", "[=color_scheme/`light`=], or "[=color_scheme/`dark`=]"), overriding other configuration members of the <a>window resource</a> object, including <a data-link-for="MiniApp window resource" data-link-type="dfn"><code>background_color</code></a>, <a><code>background_text_style</code></a>, <a><code>navigation_bar_text_style</code></a>, and <a><code>navigation_bar_title_text</code></a>.
         </p>
         <p>
           This member MUST contain one of the following <dfn>color scheme values</dfn>:  
         </p>
         <dl>
-          <dt><dfn data-dfn-for="color_scheme"><code>"auto"</code></dfn></dt>
+          <dt>"<dfn data-dfn-for="color_scheme"><code>auto</code></dfn>"</dt>
           <dd>The theme color is adapted to the system theme color.</dd>
-          <dt><dfn data-dfn-for="color_scheme"><code>"light"</code></dfn></dt>
+          <dt>"<dfn data-dfn-for="color_scheme"><code>light</code></dfn>"</dt>
           <dd>For a light color scheme.</dd>
-          <dt><dfn data-dfn-for="color_scheme"><code>"dark"</code></dfn></dt>
+          <dt>"<dfn data-dfn-for="color_scheme"><code>dark</code></dfn>"</dt>
           <dd>For a dark color scheme.</dd>
         </dl>
         <p class="note" title='Usage' data-cite="MEDIAQUERIES-5">
@@ -969,7 +969,7 @@
           <span><code>version</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <dfn><code>version</code></dfn> member contains a <a>MiniApp version resource</a> [=ordered map=] to represent the <dfn><code>code</code></dfn> and <dfn><code>name</code></dfn>.
+          The [=MiniApp manifest's=] <dfn><code>version</code></dfn> member contains a <a>MiniApp version resource</a> [=ordered map=] to represent the <a data-link-for="MiniApp version resource" data-link-type="dfn"><code>code</code></a> and <a data-link-for="MiniApp version resource" data-link-type="dfn"><code>name</code></a>.
         </p>
         <p>
           To <dfn>process the <code>version</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
@@ -1324,15 +1324,15 @@
     <section data-cite="CSS-COLOR-4 MEDIAQUERIES-5">
       <h3><code>background_text_style</code> member</h3>
       <p>
-        <span>The <dfn><code>background_text_style</code></dfn> member is a [=string=] that specifies the background text style, indicating a light or dark color theme.</span>
+        <span>The <dfn><code>background_text_style</code></dfn> member is a [=string=] that specifies the background text style, indicating a light or dark color theme (i.e., "[=background text style values/`light`=]" or "[=background text style values/`dark`=]").</span>
       </p>
       <p>
         This member supports the values of <a data-xref-type="css-descriptor" data-xref-for="@media">prefers-color-scheme</a> and MUST contain one of the following <dfn>background text style values</dfn>:  
       </p>
       <dl>
-        <dt>"<dfn data-dfn-for="background text style values">light</dfn>"</dt>
+        <dt>"<dfn data-dfn-for="background text style values"><code>light</code></dfn>"</dt>
         <dd>For light style.</dd>
-        <dt>"<dfn data-dfn-for="background text style values">dark</dfn>" (default)</dt>
+        <dt>"<dfn data-dfn-for="background text style values"><code>dark</code></dfn>" (default)</dt>
         <dd>For dark style.</dd>
       </dl>      
       <p>
@@ -1564,64 +1564,23 @@
   </section>
 
   <section>
-    <h2>Security considerations</h2>
-    <p>
-      The manifest data helps platforms to configure and process applications properly. The information exposed by the document is public, so third-party agents (e.g., app marketplaces and repositories) may use the manifest information to maintain app versions, classify, and list them.
-    </p>
-    <p>
-      As the manifest is a JSON document and will commonly be encoded using [[UNICODE]], the security considerations described in [[JSON]] and [[UNICODE-SECURITY]] apply. In order to prevent developers from including custom/unrestrained data in a manifest, implementors may use a more strict schema than that defined in <a href="#sec-json-schema">JSON Schema</a> to impose their implementation-specific limits on the member names, types, and value ranges (e.g., to guard against memory overflow, or to meet platform-specific limitations).
-    </p>
-    <p> 
-      The integrity of the MiniApp resources, including the manifest, is protected by a cryptographic hash mechanism as part of the whole <a data-link-type="dfn" href="https://www.w3.org/TR/miniapp-packaging/#dfn-package">MiniApp Package</a>, as detailed in [[MINIAPP-PACKAGING]].
-    </p>
-    <p>
-      MiniApp contains different file resources <a href="https://www.w3.org/TR/miniapp-packaging/#sec-filestructure">organized in directories</a> within a <a href="https://www.w3.org/TR/miniapp-packaging/#sec-miniapp-zip-container">container</a>. Manifest members like <a><code>icons</code></a>, <a><code>pages</code></a>, and <a><code>widgets</code></a> contain paths referring to local resources on the hosting platform. MiniApp user agents must guarantee the sandboxed environment, checking the validity of those paths to prevent illegal access out of a MiniApp <a data-link-type="dfn" href="https://www.w3.org/TR/miniapp-packaging/#dfn-package">package</a>.
-    </p>
-    <p>
-      Developers may access external MiniApp data resources (i.e., not included in the main package) on the hosting platform (e.g., deep-links to other applications and shared storages) or remote HTTP servers. In the former case, the MiniApp user agent should implement all the required mechanisms to guarantee the sandboxed environment on the platform.
-    </p>
-    <p>
-      The <a><code>pages</code></a> member defines the routes of the components of a MiniApp, including a map of pages with a relative path referring to resources stored within the MiniApp container. User agents MUST ignore external URLs or paths that do not correspond to a valid resource in the MiniApp container.  
-    </p>
-    <p>
-      The manifest specifies the features that could be requested during the operation of a MiniApp, involving access to sensors and communication with other devices, both via network connections and via direct connection to the device (e.g., via Bluetooth, NFC, or USB). The declaration does not imply the access and use of the feature. However, user agents MUST implement mechanisms to guarantee the correct usage of services and APIs and address the potential vulnerabilities in each concrete feature.
-    </p>
-    <div class="issue">
-      <p>
-        Still to define the security policy to fetch icon images described in the manifest. The Web App Manifest <a href="https://www.w3.org/TR/appmanifest/#content-security-policy">is based</a> on the `img-src` directive [[CSP3]], associated with the manifest's owner `Document`. However, this solution is not valid for the MiniApp manifest because it does not have HTTP headers associated.
-      </p>
-      <p>
-        Should we define a new MiniApp manifest member to indicate the Content Security Policy (CSP) to control the resources that a MiniApp can fetch or execute? This should be also explained in the Security Considerations of the Packaging specification.
-      </p>
-      <p>
-        What happens when `file:`, `data:`, `javascript:`, or `blob:` URLs are passed? 
-      </p>
-    </div>
-  </section>
+    <h2>Security and Privacy Considerations</h2>
+    <section>
+        <h2>Content constraint</h2>
+        <p>
+            As the manifest is a JSON document and will commonly be encoded using [[UNICODE]], the security considerations described in [[JSON] and [[UNICODE-SECURITY]] apply. In order to prevent developers from including custom/unrestrained data in a manifest, implementors may use a more strict schema than that defined in <a href="#sec-json-schema">JSON Schema</a> to impose their implementation-specific limits on the member names, types, and value ranges (e.g., to guard against memory overflow, or to meet platform-specific limitations).
+        </p>
+    </section>
 
-  <section>
-    <h2>Privacy considerations</h2>
-    <p>
-      This specification does not directly deal with sensitive data. However, the information defined in a MiniApp manifest helps the platform configure its privacy policies to let a MiniApp manage other devices' hardware, software, and data resources that could affect privacy.
-    </p>
-    <p>
-      The MiniApp manifest does not motivate collecting, using, or disclosing personal data. However, MiniApp user agents must control the access to sensitive device's services and features that could contribute to fingerprinting. User's behavioral patterns in permission management, along with the device's specific constraints (i.e., MiniApps for automotive, IoT, and SmartTVs), could allow users to be fingerprinted. For this reason, MiniApp user agents MUST control the access to the device's resources and preserve the sandboxed environment, protecting the access to sensitive resources, such as device sensors, external software, and personal data, with no disclosure of user's preferences. 
-    </p> 
-    <p>
-      Through the manifest's <a><code>req_permissions</code></a> member, developers declare the requirements of a MiniApp to access privacy-related sensitive and high-level privileged resources. This member allows the platform to understand the specific restricted resources the MiniApp may request (<a data-link-for="MiniApp permission resource" data-link-type="dfn"><code>name</code></a> member), informing the user about the potential consequences and granting (or keeping blocked) access to these resources. Developers SHOULD use the <a><code>reason</code></a> member to state the clear and easy-to-understand rationale for requesting these advanced resources. 
-    </p>
-    <p>
-      User agents MUST manage the user's preferences, including the explicit permissions the user shall grant to use sensitive system's features (e.g., geolocation and device's sensors). The user agent SHOULD implement mechanisms to remember their preferences, and the end-user SHALL explicitly decide if this information is stored across sessions. No other information related to the manifest should persist across sessions.
-    </p>
-    <p>
-      As in Web applications, MiniApps can be installed using UI dialogs. In the installation process, the user agent SHOULD display clear information about the app (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, <a><code>name</code></a>, <a><code>description</code></a>). This transparent information allows end-users to make a conscious decision before installing it.
-    </p>
-    <p>
-      User agents SHOULD provide a mechanism to remove an installed MiniApp.  It is RECOMMENDED that at the time of removal, the user agent also presents the user with an opportunity to revoke other persistent data and settings associated with the application, such as permissions and persistent storage.
-    </p>
-    <p>
-      The manifest's <a><code>window</code></a> member defines the appearance of the MiniApp, including the look and feel of the navigation bar and other features that modify the user agent's native UI, like <a><code>fullscreen</code></a> or <a><code>orientation</code></a>. User agents must offer intuitive mechanisms to close the apps, reverting the changes that affected the native UI. 
-    </p>
+    <section>
+        <h2>Local resource access</h2>
+        <p>
+          Members like <a><code>icons</code></a>, <a><code>pages</code></a>, and <a><code>widgets</code></a> contain paths referring to local resources on the hosting platform. Implementors and the hosting platform should check the validity of those paths to prevent illegal access out of the scope of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-package">MiniApp Package</a>. On the other hand, the MiniApp itself (e.g., using scripting code) may provide mechanisms to access external resources either on the hosting platform or on remote websites (e.g., through a URI). In this case, the hosting platform is responsible for providing a clear indication to an end-user about such a context switch.
+        </p>
+	      <p>
+         Additionally, the <a><code>req_permissions</code></a> member provides a specific means to control the access the local software, hardware, and data resources on the user's device. User's consent should be asked when it comes to privacy-related or high-level privileged resources.
+        </p>
+    </section>
   </section>
 
   <section class="appendix" id="conformance">

--- a/index.html
+++ b/index.html
@@ -1569,7 +1569,7 @@
       The manifest data helps platforms to configure and process applications properly. The information exposed by the document is public, so third-party agents (e.g., app marketplaces and repositories) may use the manifest information to maintain app versions, classify, and list them.
     </p>
     <p>
-      As the manifest is a JSON document and will commonly be encoded using [[UNICODE]], the security considerations described in [[JSON] and [[UNICODE-SECURITY]] apply. In order to prevent developers from including custom/unrestrained data in a manifest, implementors may use a more strict schema than that defined in <a href="#sec-json-schema">JSON Schema</a> to impose their implementation-specific limits on the member names, types, and value ranges (e.g., to guard against memory overflow, or to meet platform-specific limitations).
+      As the manifest is a JSON document and will commonly be encoded using [[UNICODE]], the security considerations described in [[JSON]] and [[UNICODE-SECURITY]] apply. In order to prevent developers from including custom/unrestrained data in a manifest, implementors may use a more strict schema than that defined in <a href="#sec-json-schema">JSON Schema</a> to impose their implementation-specific limits on the member names, types, and value ranges (e.g., to guard against memory overflow, or to meet platform-specific limitations).
     </p>
     <p> 
       The integrity of the MiniApp resources, including the manifest, is protected by a cryptographic hash mechanism as part of the whole <a data-link-type="dfn" href="https://www.w3.org/TR/miniapp-packaging/#dfn-package">MiniApp Package</a>, as detailed in [[MINIAPP-PACKAGING]].

--- a/index.html
+++ b/index.html
@@ -1583,6 +1583,18 @@
          Additionally, the <a><code>req_permissions</code></a> member provides a specific means to control the access the local software, hardware, and data resources on the user's device. User's consent should be asked when it comes to privacy-related or high-level privileged resources.
         </p>
     </section>
+
+    <section>
+        <h2>Integrity</h2>
+        <p> The integrity of the manifest document is protected by a cryptographic hash mechanism as part of the whole <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-package">MiniApp Package</a>, as detailed in [[MINIAPP-PACKAGING]]. </p>
+    </section>
+
+    <section>
+        <h2>Transparency</h2>
+        <p>
+          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, <a><code>name</code></a>, <a><code>description</code></a>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
+        </p>
+    </section>
   </section>
 
   <section class="appendix" id="conformance">

--- a/index.html
+++ b/index.html
@@ -1547,7 +1547,7 @@
     </p>
   </section>
 
-  <section>
+  <section class="informative">
     <h2>Accessibility considerations</h2>
     <p>
       This document specifies a set of metadata, enabling developers and publishers to describe and configure the behavior and appearance of MiniApps. Some manifest attributes, like `color_scheme` and the `window` resource members, aim user agents to generate customized user interfaces to enable interaction between the user and the MiniApp.

--- a/index.html
+++ b/index.html
@@ -880,7 +880,7 @@
           A <dfn data-lt="page route|page routes">MiniApp page route</dfn> is the relative path and filename of a MiniApp Page.
         </p> 
         <p>
-          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/component/mypage</samp>).
+          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/pages/mypage</samp>).
         </p>
         <p>
           The first item in the <a><code>pages</code></a> [=list=] defines the homepage of a MiniApp.

--- a/index.html
+++ b/index.html
@@ -874,16 +874,13 @@
           <span><code>pages</code> member</span>
         </h3>
         <p>
-            The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a [=page route=].
+            The [=MiniApp manifest's=] <dfn><code>pages</code></dfn> member is a [=list=] of [=relative-url string=] used for specifying the collection of pages that are part of a MiniApp. Each item in the [=list=] represents a page identified by its [=page route=].
         </p> 
         <p>
-          A <dfn data-lt="page route|page routes">MiniApp page route</dfn> is the relative path and filename of a MiniApp Page.
-        </p> 
-        <p>
-          During the MiniApp development process, adding or deleting <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp pages</a> is done by configuring the list of references. When configuring the [=page routes=], the file name extension MAY be omitted (e.g., <samp>/pages/mypage</samp>).
+          A <dfn data-lt="route|page route|page routes">MiniApp page route</dfn> is the relative path and filename of a <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">MiniApp page</a>. When configuring the [=page routes=], developers MAY omit the extension of the file that defines the main component of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-page">page</a> (e.g., <samp>/pages/mypage</samp> or <samp>/pages/mypage.html</samp>).
         </p>
         <p>
-          The first item in the <a><code>pages</code></a> [=list=] defines the homepage of a MiniApp.
+          The first item in the <a><code>pages</code></a> [=list=] defines the homepage or entry point of a MiniApp.
         </p>
         <div class="note" title="Usage">
           <p>

--- a/index.html
+++ b/index.html
@@ -1592,7 +1592,7 @@
     <section>
         <h2>Transparency</h2>
         <p>
-          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, <a><code>name</code></a>, <a><code>description</code></a>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
+          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, and <a><code>description</code></a>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
         </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -1562,36 +1562,63 @@
       User agents interpreting this manifest should help users orient within and control windows and viewports. They should also provide alternative views addressing the different usage scenarios through the advanced use of the `device_type` member and extending the manifest with vendor-specific members to enhance accessibility. Thus, MiniApp user agents and platforms should provide mechanisms for configuring user stylesheets, themes and customize the display and interaction with the application, complying with the applicable specifications and conventions, in particular the [[[UAAG20]]].
     </p>
   </section>
+
   <section>
-    <h2>Security and privacy considerations</h2>
-    <section>
-        <h2>Content constraint</h2>
-        <p>
-            As the manifest is a JSON document and will commonly be encoded using [[UNICODE]], the security considerations described in [[JSON] and [[UNICODE-SECURITY]] apply. In order to prevent developers from including custom/unrestrained data in a manifest, implementors may use a more strict schema than that defined in <a href="#sec-json-schema">JSON Schema</a> to impose their implementation-specific limits on the member names, types, and value ranges (e.g., to guard against memory overflow, or to meet platform-specific limitations).
-        </p>
-    </section>
+    <h2>Security considerations</h2>
+    <p>
+      The manifest data helps platforms to configure and process applications properly. The information exposed by the document is public, so third-party agents (e.g., app marketplaces and repositories) may use the manifest information to maintain app versions, classify, and list them.
+    </p>
+    <p>
+      As the manifest is a JSON document and will commonly be encoded using [[UNICODE]], the security considerations described in [[JSON] and [[UNICODE-SECURITY]] apply. In order to prevent developers from including custom/unrestrained data in a manifest, implementors may use a more strict schema than that defined in <a href="#sec-json-schema">JSON Schema</a> to impose their implementation-specific limits on the member names, types, and value ranges (e.g., to guard against memory overflow, or to meet platform-specific limitations).
+    </p>
+    <p> 
+      The integrity of the MiniApp resources, including the manifest, is protected by a cryptographic hash mechanism as part of the whole <a data-link-type="dfn" href="https://www.w3.org/TR/miniapp-packaging/#dfn-package">MiniApp Package</a>, as detailed in [[MINIAPP-PACKAGING]].
+    </p>
+    <p>
+      MiniApp contains different file resources <a href="https://www.w3.org/TR/miniapp-packaging/#sec-filestructure">organized in directories</a> within a <a href="https://www.w3.org/TR/miniapp-packaging/#sec-miniapp-zip-container">container</a>. Manifest members like <a><code>icons</code></a>, <a><code>pages</code></a>, and <a><code>widgets</code></a> contain paths referring to local resources on the hosting platform. MiniApp user agents must guarantee the sandboxed environment, checking the validity of those paths to prevent illegal access out of a MiniApp <a data-link-type="dfn" href="https://www.w3.org/TR/miniapp-packaging/#dfn-package">package</a>.
+    </p>
+    <p>
+      Developers may access external MiniApp data resources (i.e., not included in the main package) on the hosting platform (e.g., deep-links to other applications and shared storages) or remote HTTP servers. In the former case, the MiniApp user agent should implement all the required mechanisms to guarantee the sandboxed environment on the platform.
+    </p>
+    <p>
+      The <a><code>pages</code></a> member defines the routes of the components of a MiniApp, including a map of pages with a relative path referring to resources stored within the MiniApp container. User agents MUST ignore external URLs or paths that do not correspond to a valid resource in the MiniApp container.  
+    </p>
+    <p>
+      The manifest specifies the features that could be requested during the operation of a MiniApp, involving access to sensors and communication with other devices, both via network connections and via direct connection to the device (e.g., via Bluetooth, NFC, or USB). The declaration does not imply the access and use of the feature. However, user agents MUST implement mechanisms to guarantee the correct usage of services and APIs and address the potential vulnerabilities in each concrete feature.
+    </p>
+    <div class="issue">
+      <p>
+        Still to define the security policy to fetch icon images described in the manifest. The Web App Manifest <a href="https://www.w3.org/TR/appmanifest/#content-security-policy">is based</a> on the `img-src` directive [[CSP3]], associated with the manifest's owner `Document`. However, this solution is not enough for the MiniApp manifest since the manifest does not always have HTTP headers associated. 
+      </p>
+      <p>
+        What happens when `file:`, `data:`, or `blob:` URLs are passed? 
+      </p>
+    </div>
+  </section>
 
-    <section>
-        <h2>Local resource access</h2>
-        <p>
-          Members like <a><code>icons</code></a>, <a><code>pages</code></a>, and <a><code>widgets</code></a> contain paths referring to local resources on the hosting platform. Implementors and the hosting platform should check the validity of those paths to prevent illegal access out of the scope of the <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-package">MiniApp Package</a>. On the other hand, the MiniApp itself (e.g., using scripting code) may provide mechanisms to access external resources either on the hosting platform or on remote websites (e.g., through a URI). In this case, the hosting platform is responsible for providing a clear indication to an end-user about such a context switch.
-        </p>
-	      <p>
-         Additionally, the <a><code>req_permissions</code></a> member provides a specific means to control the access the local software, hardware, and data resources on the user's device. User's consent should be asked when it comes to privacy-related or high-level privileged resources.
-        </p>
-    </section>
-
-    <section>
-        <h2>Integrity</h2>
-        <p> The integrity of the manifest document is protected by a cryptographic hash mechanism as part of the whole <a data-link-type="dfn" href="https://w3c.github.io/miniapp-packaging/#dfn-package">MiniApp Package</a>, as detailed in [[MINIAPP-PACKAGING]]. </p>
-    </section>
-
-    <section>
-        <h2>Transparency</h2>
-        <p>
-          The user agent SHOULD provide the end-user with transparent metadata about a MiniApp (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, <a><code>name</code></a>, <a><code>description</code></a>), offering users enough information, allowing them to make a conscious decision about its usage. This practice could also help to identify spoofing MiniApps.
-        </p>
-    </section>
+  <section>
+    <h2>Privacy considerations</h2>
+    <p>
+      This specification does not directly deal with sensitive data. However, the information defined in a MiniApp manifest helps the platform configure its privacy policies to let a MiniApp manage other devices' hardware, software, and data resources that could affect privacy.
+    </p>
+    <p>
+      The MiniApp manifest does not motivate collecting, using, or disclosing personal data. However, MiniApp user agents must control the access to sensitive device's services and features that could contribute to fingerprinting. User's behavioral patterns in permission management, along with the device's specific constraints (i.e., MiniApps for automotive, IoT, and SmartTVs), could allow users to be fingerprinted. For this reason, MiniApp user agents MUST control the access to the device's resources and preserve the sandboxed environment, protecting the access to sensitive resources, such as device sensors, external software, and personal data, with no disclosure of user's preferences. 
+    </p> 
+    <p>
+      Through the manifest's <a><code>req_permissions</code></a> member, developers declare the requirements of a MiniApp to access privacy-related sensitive and high-level privileged resources. This member allows the platform to understand the specific restricted resources the MiniApp may request (<a data-link-for="MiniApp permission resource" data-link-type="dfn"><code>name</code></a> member), informing the user about the potential consequences and granting (or keeping blocked) access to these resources. Developers SHOULD use the <a><code>reason</code></a> member to state the clear and easy-to-understand rationale for requesting these advanced resources. 
+    </p>
+    <p>
+      User agents MUST manage the user's preferences, including the explicit permissions the user shall grant to use sensitive system's features (e.g., geolocation and device's sensors). The user agent SHOULD implement mechanisms to remember their preferences, and the end-user SHALL explicitly decide if this information is stored across sessions. No other information related to the manifest should persist across sessions.
+    </p>
+    <p>
+      As in Web applications, MiniApps can be installed using UI dialogs. In the installation process, the user agent SHOULD display clear information about the app (i.e., <a><code>app_id</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a>, <a><code>short_name</code></a>, <a>icons</a>, <a><code>name</code></a>, <a><code>description</code></a>). This transparent information allows end-users to make a conscious decision before installing it.
+    </p>
+    <p>
+      User agents SHOULD provide a mechanism to remove an installed MiniApp.  It is RECOMMENDED that at the time of removal, the user agent also presents the user with an opportunity to revoke other persistent data and settings associated with the application, such as permissions and persistent storage.
+    </p>
+    <p>
+      The manifest's <a><code>window</code></a> member defines the appearance of the MiniApp, including the look and feel of the navigation bar and other features that modify the user agent's native UI, like <a><code>fullscreen</code></a> or <a><code>orientation</code></a>. User agents must offer intuitive mechanisms to close the apps, reverting the changes that affected the native UI. 
+    </p>
   </section>
 
   <section class="appendix" id="conformance">

--- a/index.html
+++ b/index.html
@@ -719,7 +719,10 @@
         </dl>
         <p class="note" title="Processing the `icons` member">
           When [=processing a MiniApp manifest=], the <a href="https://www.w3.org/TR/appmanifest/#dfn-process-image-resources" data-link-type="dfn">process image resources</a> algorithm is used to process the <code>icons</code> member, according to the [[APPMANIFEST]] specification.
-        </p>        
+        </p>
+        <p class="note" title="Accessibility considerations">
+          Developers are strongly encouraged to add a `label` unless the [=image resource=]’s accessible name can be inferred from an external label in its context.
+        </p>
       </section>      
       <section>
         <h3>

--- a/index.html
+++ b/index.html
@@ -1548,6 +1548,21 @@
   </section>
 
   <section>
+    <h2>Accessibility Considerations</h2>
+    <p>
+      This document specifies a set of metadata, enabling developers and publishers to describe and configure the behavior and appearance of MiniApps. Some manifest attributes, like `color_scheme` and the `window` resource members, aim user agents to generate customized user interfaces to enable interaction between the user and the MiniApp.
+    </p>
+    <p>
+      The <a><code>icons</code></a> member allows developers to describe the visual and iconic representation of a MiniApp in the platform and operating system. Here, the platform should adequately communicate with the platform accessibility services to represent the images, also using the alternative textual descriptions (e.g., <a><code>icon</code></a>'s <a href="https://www.w3.org/TR/image-resource/#dfn-label" data-link-type="dfn"><code>label</code></a>, <a data-link-for="MiniApp manifest" data-link-type="dfn"><code>name</code></a> and <a><code>short_name</code></a>) to enhance accessibility (i.e., icons in the home screen of the device, listing in app directories, and app configuration).
+    </p>
+    <p>
+      User agents must ensure that the user interface is perceivable and operable, so they should take special consideration when processing the members that affect the user agent interface and the rendered content, like with the setup of color schemes and themes (i.e., <a><code>color_scheme</code></a>, <a data-link-for="MiniApp window resource" data-link-type="dfn"><code>background_color</code></a>, <a><code>background_text_style</code></a>, <a><code>navigation_bar_background_color</code></a>, <a><code>navigation_bar_background_color</code></a>, <a><code>navigation_bar_text_style</code></a>, and <a><code>navigation_style</code></a>) and other configuration settings like <a><code>orientation</code></a>, <a><code>fullscreen</code></a>, <a><code>enable_pull_down_refresh</code></a>, and <a><code>on_reach_bottom_distance</code></a>.
+    </p>
+    <p>
+      User agents interpreting this manifest should help users orient within and control windows and viewports. They should also provide alternative views addressing the different usage scenarios through the advanced use of the `device_type` member and extending the manifest with vendor-specific members to enhance accessibility. Thus, MiniApp user agents and platforms should provide mechanisms for configuring user stylesheets, themes and customize the display and interaction with the application, complying with the applicable specifications and conventions, in particular the [[[UAAG20]]].
+    </p>
+  </section>
+  <section>
     <h2>Security and Privacy Considerations</h2>
     <section>
         <h2>Content constraint</h2>


### PR DESCRIPTION
No issue associated.  

This change:

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

If it changes the specification itself, the following tasks have been completed:

* [X] Confirmed there are no ReSpec errors.

Commit message:

Fixing definitions and missing links to them. 
Some of the algorithms were not properly linked. The behavior is the same the group expected.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-manifest/pull/40.html" title="Last updated on Mar 4, 2022, 9:57 AM UTC (00b25a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/40/f5166ad...espinr:00b25a7.html" title="Last updated on Mar 4, 2022, 9:57 AM UTC (00b25a7)">Diff</a>