### PR TITLE
app_id value is case sensitive as suggested in #7

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,7 +787,7 @@
           The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp univocally. This member is mainly used for package management, and it supports the update and release process of MiniApp versioning.
         </p>
         <p>
-          The format of <code>[=app_id=]</code> is RECOMMENDED to be a [=string=] defined by the following rule:
+          The format of <code>[=app_id=]</code> is RECOMMENDED to be a case sensitive [=string=] defined by the following rule:
         </p>
         <pre class="abnf">
           appIdRule = name *("." name)

--- a/index.html
+++ b/index.html
@@ -787,7 +787,7 @@
           The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp univocally. This member is mainly used for package management, and it supports the update and release process of MiniApp versioning.
         </p>
         <p>
-          The format of <code>[=app_id=]</code> is RECOMMENDED to be a case sensitive [=string=] defined by the following rule:
+          The value of <code>[=app_id=]</code> is RECOMMENDED <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is">to be</a> a [=string=] defined by the following rule:
         </p>
         <pre class="abnf">
           appIdRule = name *("." name)

--- a/manifest_schema.json
+++ b/manifest_schema.json
@@ -85,7 +85,7 @@
     },
     "app_id": {
       "type": "string",
-      "description": "A string that identifies the MiniApp univocally.",
+      "description": "A case sensitive string that identifies the MiniApp univocally.",
       "example": "org.example.miniapp"
     },
     "color_scheme": {


### PR DESCRIPTION
Closes #7 

This change (choose at least one, delete ones that don't apply):

* Adds new normative recommendations or optional items

If it changes the specification itself, the following tasks have been completed:

* [X] Confirmed there are no ReSpec errors.

If change is normative, and it adds or changes a member:

* [X] [updated JSON schema](https://github.com/w3c/miniapp-manifest/blob/main/manifest_schema.json)
* [] [updated explainer](https://github.com/w3c/miniapp-manifest/blob/main/docs/explainer.md) (N/A)

Commit message:
`app_id` value is case sensitive as suggested in #7


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-manifest/pull/58.html" title="Last updated on Sep 12, 2022, 10:25 AM UTC (bf459c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/58/3e2f56b...espinr:bf459c4.html" title="Last updated on Sep 12, 2022, 10:25 AM UTC (bf459c4)">Diff</a>