### PR TITLE
Clarification of differences with Web app manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,9 @@
     <p>
       A <dfn data-export="" data-lt="MiniApp manifest's|manifest">MiniApp manifest</dfn> is a [[JSON]] document that extends and profiles the Web App Manifest [[APPMANIFEST]] and the Web App Manifest - Application Information [[MANIFEST-APP-INFO]], to describe metadata associated with a MiniApp.
     </p>
+    <p class="note">
+      This specification defines the set of metadata to describe MiniApps, extending the [[[APPMANIFEST]]] and the [[[MANIFEST-APP-INFO]]] by providing additional mechanisms to describe and set up MiniApps. The MiniApp Manifest directly reuses essential elements from these specifications (i.e., `name`, `short_name`, `description`, and `icons`), adding supplementary members that specifically affect MiniApps (e.g., `app_id`, `version`, `platform_version`, `device_type`, `pages`, `req_permissions`, and `widgets`) and their look and feel (e.g., `color_scheme` and `window`).       
+    </p> 
     <section id="manifest-conformance" data-cite="IMAGE-RESOURCE">
       <h3>Conformance</h3>
       <p>

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
       A <dfn data-export="" data-lt="MiniApp manifest's|manifest">MiniApp manifest</dfn> is a [[JSON]] document that extends and profiles the Web App Manifest [[APPMANIFEST]] and the Web App Manifest - Application Information [[MANIFEST-APP-INFO]], to describe metadata associated with a MiniApp.
     </p>
     <p class="note">
-      This specification defines the set of metadata to describe MiniApps, extending the [[[APPMANIFEST]]] and the [[[MANIFEST-APP-INFO]]] by providing additional mechanisms to describe and set up MiniApps. The MiniApp Manifest directly reuses essential elements from these specifications (i.e., `name`, `short_name`, `description`, and `icons`), adding supplementary members that specifically affect MiniApps (e.g., `app_id`, `version`, `platform_version`, `device_type`, `pages`, `req_permissions`, and `widgets`) and their look and feel (e.g., `color_scheme` and `window`).       
+      This specification defines the set of metadata to describe MiniApps, extending the [[[APPMANIFEST]]] and the [[[MANIFEST-APP-INFO]]] by providing additional constraints and specific mechanisms to describe and set up MiniApps. The MiniApp Manifest directly reuses essential elements from these specifications (i.e., `name`, `short_name`, `description`, and `icons`), adding supplementary members that specifically affect MiniApps (e.g., `app_id`, `version`, `platform_version`, `device_type`, `pages`, `req_permissions`, and `widgets`) and their look and feel (e.g., `color_scheme` and `window`).       
     </p> 
     <section id="manifest-conformance" data-cite="IMAGE-RESOURCE">
       <h3>Conformance</h3>


### PR DESCRIPTION
Closes #54 

This change:

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

If it changes the specification itself, the following tasks have been completed:

* [X] Confirmed there are no ReSpec errors.

Commit message:

(Informative) Note in the introduction to clarify the differences.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-manifest/pull/59.html" title="Last updated on Sep 12, 2022, 10:36 AM UTC (0273dc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/59/3e2f56b...espinr:0273dc0.html" title="Last updated on Sep 12, 2022, 10:36 AM UTC (0273dc0)">Diff</a>