### PR TITLE
App id refinement based on i18n review

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,7 +790,7 @@
           The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a case-sensitive [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
         </p>
         <p>
-          The value of <code>[=app_id=]</code> SHOULD be defined by the following rule:
+          Although the value of <code>[=app_id=]</code> can be any [=string=], it SHOULD be defined by the following rule:
         </p>
         <pre class="abnf">
           appIdRule = name *("." name)

--- a/index.html
+++ b/index.html
@@ -786,19 +786,21 @@
         <h3>
           <span><code>app_id</code> member</span>
         </h3>
+        <p data-cite="i18n-glossary">
+          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
+        </p> 
         <p>
-          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a case-sensitive [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
+          The value of <code>[=app_id=]</code> is both case-sensitive and sensitive to different ways of encoding characters in Unicode. Consequently, two <code>[=app_id=]</code> values are equal only if they are encoded as the same sequence of <a href="https://www.w3.org/TR/i18n-glossary/#def_unicode_code_point" data-link-type="dfn">code points</a>.
         </p>
-        <p>
-          Although the value of <code>[=app_id=]</code> can be any [=string=], it SHOULD be defined by the following rule:
-        </p>
-        <pre class="abnf">
-          appIdRule = name *("." name)
-          name = ALPHA [*( ALPHA / DIGIT / "-" ) ( ALPHA / DIGIT)]
-        </pre>
-        <p class="note" title='Usage'>
-              One common practice is to use the reverse-domain-name-like convention (e.g., <code>org.example.miniapp</code>).
-        </p>
+        <div class="note" title='Usage'>
+          <p>
+              One common practice for MiniApps is to use the reverse-domain-name-like convention used by the <a href="https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html">Java package naming convention</a> (e.g., <code>org.example.miniapp</code>) under the following rule:
+          </p>
+          <pre class="abnf">
+            appIdRule = name *("." name)
+            name = ALPHA [*( ALPHA / DIGIT / "-" ) ( ALPHA / DIGIT)]
+          </pre>              
+        </div>
         <p>
           To <dfn>process the <code>app_id</code> member</dfn>, given [=ordered map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
         </p>

--- a/index.html
+++ b/index.html
@@ -790,7 +790,7 @@
           The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is">is</a> a [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
         </p>
         <p>
-          The value of <code>[=app_id=]</code> is defined by the following rule:
+          The value of <code>[=app_id=]</code> SHOULD be defined by the following rule:
         </p>
         <pre class="abnf">
           appIdRule = name *("." name)

--- a/index.html
+++ b/index.html
@@ -787,10 +787,10 @@
           <span><code>app_id</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, and it supports the update and release process of MiniApp versioning.
+          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is">is</a> a [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
         </p>
         <p>
-          The value of <code>[=app_id=]</code> is RECOMMENDED <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is">to be</a> a [=string=] defined by the following rule:
+          The value of <code>[=app_id=]</code> is defined by the following rule:
         </p>
         <pre class="abnf">
           appIdRule = name *("." name)

--- a/index.html
+++ b/index.html
@@ -787,7 +787,7 @@
           <span><code>app_id</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp univocally. This member is mainly used for package management, and it supports the update and release process of MiniApp versioning.
+          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, and it supports the update and release process of MiniApp versioning.
         </p>
         <p>
           The value of <code>[=app_id=]</code> is RECOMMENDED <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is">to be</a> a [=string=] defined by the following rule:

--- a/index.html
+++ b/index.html
@@ -787,7 +787,7 @@
           <span><code>app_id</code> member</span>
         </h3>
         <p>
-          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is">is</a> a [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
+          The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a case-sensitive [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
         </p>
         <p>
           The value of <code>[=app_id=]</code> SHOULD be defined by the following rule:

--- a/manifest_schema.json
+++ b/manifest_schema.json
@@ -85,7 +85,7 @@
     },
     "app_id": {
       "type": "string",
-      "description": "A case sensitive string that identifies the MiniApp univocally.",
+      "description": "A string containing a unique identifier for the MiniApp; case-sensitive.",
       "example": "org.example.miniapp"
     },
     "color_scheme": {


### PR DESCRIPTION
Closes #7 

This change (choose at least one, delete ones that don't apply):

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)

If it changes the specification itself, the following tasks have been completed:

* [X] Confirmed there are no ReSpec errors.

Commit message:

- Based on @aphillips' suggestions on the PR #58 and issue #7
- Appropriate wording (uniquely instead of univocally)
- Clarify the 'is string' INFRA definition.
- Avoid misunderstandings with the word RECOMMENDED.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-manifest/pull/61.html" title="Last updated on Dec 14, 2022, 3:19 PM UTC (a3b9fcf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/61/29e2f28...espinr:a3b9fcf.html" title="Last updated on Dec 14, 2022, 3:19 PM UTC (a3b9fcf)">Diff</a>