### PR TITLE
Update broken reference (Unicode)

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,7 +790,7 @@
           The [=MiniApp manifest's=] <code><dfn>app_id</dfn></code> member is a [=string=] that identifies the MiniApp uniquely. This member is mainly used for package management, supporting the update and release process of MiniApp versioning.
         </p> 
         <p>
-          The value of <code>[=app_id=]</code> is both case-sensitive and sensitive to different ways of encoding characters in Unicode. Consequently, two <code>[=app_id=]</code> values are equal only if they are encoded as the same sequence of <a href="https://www.w3.org/TR/i18n-glossary/#def_unicode_code_point" data-link-type="dfn">code points</a>.
+          The value of <code>[=app_id=]</code> is both case-sensitive and sensitive to different ways of encoding characters in Unicode. Consequently, two <code>[=app_id=]</code> values are equal only if they are encoded as the same sequence of <a href="https://www.w3.org/TR/i18n-glossary/#dfn-unicode-code-point" data-link-type="dfn">code points</a>.
         </p>
         <div class="note" title='Usage'>
           <p>


### PR DESCRIPTION
Closes #65 

This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

If it changes the specification itself, the following tasks have been completed:

* [X] Confirmed there are no ReSpec errors.


Commit message:

Fixed broken link to reference (thanks @xfq )


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/espinr/miniapp-manifest/pull/66.html" title="Last updated on May 30, 2023, 12:50 PM UTC (8723d0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/miniapp-manifest/66/29ce6a5...espinr:8723d0d.html" title="Last updated on May 30, 2023, 12:50 PM UTC (8723d0d)">Diff</a>