### PR TITLE
Removing links that were moved to incubation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -595,9 +595,7 @@
 
       <p class="note">
       Other [=application manifest=] members such as <a href="https://www.w3.org/TR/appmanifest/#scope-member"><code>scope</code></a>,
-        <a href="https://www.w3.org/TR/appmanifest/#theme_color-member"><code>theme_color</code></a>,
-        <a href="https://www.w3.org/TR/appmanifest/#related_applications-member"><code>related_applications</code></a>,
-        <a href="https://www.w3.org/TR/appmanifest/#prefer_related_applications-member"><code>prefer_related_applications</code></a>, and
+        <a href="https://www.w3.org/TR/appmanifest/#theme_color-member"><code>theme_color</code></a>, and
         <a href="https://www.w3.org/TR/appmanifest/#shortcuts-member"><code>shortcuts</code></a> are not currently supported by MiniApp user agents.
       </p>
     </section>


### PR DESCRIPTION
Closes #70

This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).

If it changes the specification itself, the following tasks have been completed:

* [X] Confirmed there are no ReSpec errors.

Commit message:

Removing Web app members that were moved to the incubation repo.